### PR TITLE
Prepare to use in Spilno

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,11 +521,11 @@ The design choice for immutable messages was made specifically to enable this ki
 
 ## 🔒 Message persistence and identification
 
-MiniAgents provides a way to persist messages as they are resolved from promises using the `@MiniAgents().on_persist_message` decorator. This allows you to implement custom logic for storing or logging messages.
+MiniAgents provides a way to persist messages as they are resolved from promises using the `@MiniAgents().on_persist_messages` decorator. This allows you to implement custom logic for storing or logging messages.
 
 Additionally, messages (as well as any other Pydantic models derived from `Frozen`) have a `hash_key` property. This property calculates the sha256 hash of the content of the message and is used as the id of the `Messages` (or any other `Frozen` model), much like there are commit hashes in git.
 
-Here's a simple example of how to use the `on_persist_message` decorator:
+Here's a simple example of how to use the `on_persist_messages` decorator:
 
 ```python
 from miniagents import MiniAgents, Message
@@ -533,10 +533,11 @@ from miniagents import MiniAgents, Message
 mini_agents = MiniAgents()
 
 
-@mini_agents.on_persist_message
-async def persist_message(_, message: Message) -> None:
-    print(f"Persisting message with hash key: {message.hash_key}")
-    # Here you could save the message to a database or log it to a file
+@mini_agents.on_persist_messages
+async def persist_messages(messages: Iterable[Message]) -> None:
+    # Here you could save the messages to a database or log them to a file
+    for message in messages:
+        print(f"Persisting message with hash key: {message.hash_key}")
 ```
 
 ## 📚 Core concepts

--- a/examples/llm_example.py
+++ b/examples/llm_example.py
@@ -3,6 +3,7 @@ Code example for using LLMs.
 """
 
 from pprint import pprint
+from typing import Iterable
 
 from dotenv import load_dotenv
 from miniagents import Message, MiniAgents
@@ -19,15 +20,16 @@ llm_agent = OpenAIAgent.fork(model="gpt-4o")
 mini_agents = MiniAgents()
 
 
-@mini_agents.on_persist_message
-async def persist_message(_, message: Message) -> None:
+@mini_agents.on_persist_messages
+async def persist_messages(messages: Iterable[Message]) -> None:
     """
-    Print the message to the console.
+    Print messages to the console.
     """
-    print("HASH KEY:", message.hash_key)
-    print(type(message).__name__)
-    pprint(message.serialize(), width=119)
-    print()
+    for message in messages:
+        print("HASH KEY:", message.hash_key)
+        print(type(message).__name__)
+        pprint(message.serialize(), width=119)
+        print()
 
 
 async def main() -> None:

--- a/examples/web_research_tutorial/TUTORIAL.md
+++ b/examples/web_research_tutorial/TUTORIAL.md
@@ -291,9 +291,9 @@ async def main():
     print("=== REPLAYING MESSAGES AGAIN ===")
     print()
 
-    # We can even await the whole sequence promise to get the full list (tuple,
-    # to be precise) of resolved messages (demonstrating the replayability of
-    # promises once again).
+    # We can even await for the whole MessageSequencePromise to get the
+    # complete tuple of resolved messages (demonstrating the replayability of
+    # the promises once again).
     messages: tuple[Message, ...] = await response_promises
     for i, message in enumerate(messages):
         # When you run this example, you will see that for agents replying with

--- a/examples/web_research_tutorial/utils.py
+++ b/examples/web_research_tutorial/utils.py
@@ -16,7 +16,7 @@ from selenium.webdriver.remote.client_config import ClientConfig
 
 load_dotenv()
 
-EXPECTED_MINIAGENTS_VERSION = (0, 0, 31)
+EXPECTED_MINIAGENTS_VERSION = (0, 0, 32)
 
 BRIGHTDATA_SERP_API_CREDS = os.environ["BRIGHTDATA_SERP_API_CREDS"]
 BRIGHTDATA_SCRAPING_BROWSER_CREDS = os.environ["BRIGHTDATA_SCRAPING_BROWSER_CREDS"]

--- a/miniagents/messages.py
+++ b/miniagents/messages.py
@@ -96,7 +96,7 @@ class Message(Frozen):
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
-        self._persist_message_event_triggered = False
+        self._persist_messages_event_triggered = False
 
     def _as_string(self) -> str:
         return f"```json\n{super()._as_string()}\n```"

--- a/miniagents/messages.py
+++ b/miniagents/messages.py
@@ -103,7 +103,7 @@ class Message(Frozen):
 
     def serialize(self) -> dict[str, Any]:
         include_into_serialization, sub_messages = self._serialization_metadata
-        model_dump = self.model_dump(include=include_into_serialization)
+        model_dump = self.model_dump(include=include_into_serialization, mode="json")
 
         for path, message_or_messages in sub_messages.items():
             sub_dict = model_dump
@@ -112,7 +112,7 @@ class Message(Frozen):
             if isinstance(message_or_messages, Message):
                 sub_dict[f"{path[-1]}__hash_key"] = message_or_messages.hash_key
             else:
-                sub_dict[f"{path[-1]}__hash_keys"] = tuple(message.hash_key for message in message_or_messages)
+                sub_dict[f"{path[-1]}__hash_keys"] = [message.hash_key for message in message_or_messages]
         return model_dump
 
     def sub_messages(self) -> Iterator["Message"]:

--- a/miniagents/miniagent_typing.py
+++ b/miniagents/miniagent_typing.py
@@ -7,8 +7,6 @@ from typing import Any, AsyncIterable, AsyncIterator, Iterable, Protocol, Union
 
 from pydantic import BaseModel
 
-from miniagents.promising.promise_typing import PromiseBound
-
 if typing.TYPE_CHECKING:
     # noinspection PyUnresolvedReferences
     from miniagents.messages import Message, MessagePromise, Token
@@ -31,8 +29,8 @@ class MessageTokenStreamer(Protocol):
     def __call__(self, auxiliary_field_collector: dict[str, Any]) -> AsyncIterator["Token"]: ...
 
 
-class PersistMessageEventHandler(Protocol):
-    async def __call__(self, promise: PromiseBound, message: "Message") -> None: ...
+class PersistMessagesEventHandler(Protocol):
+    async def __call__(self, messages: Iterable["Message"]) -> None: ...
 
 
 # Type definitions for messages in the MiniAgents framework

--- a/miniagents/miniagents.py
+++ b/miniagents/miniagents.py
@@ -108,6 +108,26 @@ class MiniAgents(PromisingContext):
         extend_with_sub_messages: bool = True,
         parallelise_handlers: bool = False,
     ) -> None:
+        """
+        Persists the given message or messages using the registered `on_persist_messages` handlers.
+
+        This method is typically called automatically when a MessagePromise is resolved (which typically
+        happens in the background when agents communicate with each other). However, it can also be called
+        manually if needed (e.g. you want to persist multiple messages to a database and do that in a single
+        database transaction that you opened).
+
+        Args:
+            message_or_messages: A single `Message` object or an iterable of `Message` objects to persist.
+            extend_with_sub_messages: If True (default), all sub-messages of the given messages (no matter the
+                depth of nesting) will also be persisted. This is useful when a message is a container for other,
+                nested messages.
+            parallelise_handlers: If True, the `on_persist_messages` handlers will be called in parallel.
+                Defaults to False, meaning the handlers will be called sequentially.
+
+        NOTE: If your objective is to persist messages in a single database transaction, you probably should not
+        parallelise the handlers (you should keep `parallelise_handlers=False`), otherwise they will be run as
+        separate async operations and most likely not be part of the transaction you opened.
+        """
         # pylint: disable=protected-access
         if isinstance(message_or_messages, Message):
             message_or_messages = [message_or_messages]

--- a/miniagents/miniagents.py
+++ b/miniagents/miniagents.py
@@ -135,14 +135,12 @@ def miniagent(
     normalize_spaces_in_docstring: bool = True,
     interaction_metadata: Optional[dict[str, Any]] = None,
     non_freezable_kwargs: Optional[dict[str, Any]] = None,
-    mutable_state: Optional[dict[str, Any]] = None,  # deprecated
     **kwargs_to_freeze,
 ) -> Union["MiniAgent", Callable[[AgentFunction], "MiniAgent"]]:
     """
     A decorator that converts an agent function into an agent.
 
     Args:
-        mutable_state: Deprecated. Use `non_freezable_kwargs` instead.
         # TODO describe all the parameters
     """
     if func_or_class is None:
@@ -156,7 +154,6 @@ def miniagent(
                 normalize_spaces_in_docstring=normalize_spaces_in_docstring,
                 interaction_metadata=interaction_metadata,
                 non_freezable_kwargs=non_freezable_kwargs,
-                mutable_state=mutable_state,
                 **kwargs_to_freeze,
             )
 
@@ -171,7 +168,6 @@ def miniagent(
         normalize_spaces_in_docstring=normalize_spaces_in_docstring,
         interaction_metadata=interaction_metadata,
         non_freezable_kwargs=non_freezable_kwargs,
-        mutable_state=mutable_state,
         **kwargs_to_freeze,
     )
 
@@ -195,25 +191,8 @@ class MiniAgent(Frozen):
         normalize_spaces_in_docstring: bool = True,
         interaction_metadata: Optional[Union[dict[str, Any], Frozen]] = None,
         non_freezable_kwargs: Optional[dict[str, Any]] = None,
-        mutable_state: Optional[dict[str, Any]] = None,  # deprecated
         **kwargs_to_freeze,
     ) -> None:
-        if mutable_state is not None:
-            warnings.warn(
-                "The `mutable_state` parameter is deprecated and will be removed in a future version. "
-                "Use `non_freezable_kwargs` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            if non_freezable_kwargs is not None:
-                raise ValueError(
-                    "Both `mutable_state` and `non_freezable_kwargs` are set. Please use only one of them "
-                    "(preferrably the latter because the former is deprecated)."
-                )
-
-            non_freezable_kwargs = mutable_state
-        del mutable_state
-
         if alias is None:
             alias = func_or_class.__name__
             if normalize_func_or_class_name:
@@ -289,7 +268,6 @@ class MiniAgent(Frozen):
         *,
         interaction_metadata: Optional[Union[dict[str, Any], Frozen]] = None,
         non_freezable_kwargs: Optional[dict[str, Any]] = None,
-        mutable_state: Optional[dict[str, Any]] = None,  # deprecated
         **kwargs_to_freeze,
     ) -> Union["MiniAgent", Callable[[AgentFunction], "MiniAgent"]]:
         """
@@ -300,28 +278,11 @@ class MiniAgent(Frozen):
             description: New description for the forked agent. If not provided, uses the original description.
             interaction_metadata: TODO explain this parameter
             non_freezable_kwargs: Additional non-freezable kwargs to merge with the original non-freezable kwargs.
-            mutable_state: Deprecated. Use `non_freezable_kwargs` instead.
             **kwargs_to_freeze: Additional static parameters for the forked agent.
 
         Returns:
             A new MiniAgent instance with the modified parameters.
         """
-        if mutable_state is not None:
-            warnings.warn(
-                "The `mutable_state` parameter is deprecated and will be removed in a future version. "
-                "Use `non_freezable_kwargs` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            if non_freezable_kwargs is not None:
-                raise ValueError(
-                    "Both `mutable_state` and `non_freezable_kwargs` are set. Please use only one of them "
-                    "(preferrably the latter because the former is deprecated)."
-                )
-
-            non_freezable_kwargs = mutable_state
-        del mutable_state
-
         return MiniAgent(
             self._func_or_class,
             alias=alias or self.alias,

--- a/miniagents/promising/ext/frozen.py
+++ b/miniagents/promising/ext/frozen.py
@@ -8,12 +8,35 @@ from functools import wraps
 from numbers import Number
 from typing import Any, Callable, Optional, Union
 from uuid import UUID
+from datetime import datetime, date, time, timedelta
+from pathlib import Path
+from ipaddress import IPv4Address, IPv6Address
+from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
 from miniagents.promising.sentinels import NO_VALUE
 
-FrozenType = Optional[Union[str, Number, bool, UUID, tuple["FrozenType", ...], "Frozen"]]
+FrozenType = Optional[
+    Union[
+        str,
+        Number,
+        bool,
+        UUID,
+        datetime,
+        date,
+        time,
+        timedelta,
+        Path,
+        IPv4Address,
+        IPv6Address,
+        Enum,
+        bytes,
+        frozenset["FrozenType"],
+        tuple["FrozenType", ...],
+        "Frozen",
+    ]
+]
 
 FROZEN_CLASS_FIELD = "class_"
 
@@ -191,4 +214,24 @@ class Frozen(BaseModel):
 
     @classmethod
     def _allowed_value_types(cls) -> tuple[type[Any], ...]:
-        return type(None), str, Number, bool, UUID, tuple, list, dict, Frozen
+        return (
+            type(None),
+            str,
+            Number,
+            bool,
+            UUID,
+            datetime,
+            date,
+            time,
+            timedelta,
+            Path,
+            IPv4Address,
+            IPv6Address,
+            Enum,
+            bytes,
+            frozenset,
+            tuple,
+            list,
+            dict,
+            Frozen,
+        )

--- a/miniagents/promising/ext/frozen.py
+++ b/miniagents/promising/ext/frozen.py
@@ -10,7 +10,6 @@ from typing import Any, Callable, Optional, Union
 from uuid import UUID
 from datetime import datetime, date, time, timedelta
 from pathlib import Path
-from ipaddress import IPv4Address, IPv6Address
 from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, model_validator
@@ -28,8 +27,6 @@ FrozenType = Optional[
         time,
         timedelta,
         Path,
-        IPv4Address,
-        IPv6Address,
         Enum,
         bytes,
         frozenset["FrozenType"],
@@ -146,7 +143,7 @@ class Frozen(BaseModel):
         Frozen object and all its nested objects. Child classes may override this method to customize serialization
         (e.g. externalize certain nested objects and only reference them by their hash keys - see Message).
         """
-        return self.model_dump()
+        return self.model_dump(mode="json")
 
     @property
     @cached_privately
@@ -225,8 +222,6 @@ class Frozen(BaseModel):
             time,
             timedelta,
             Path,
-            IPv4Address,
-            IPv6Address,
             Enum,
             bytes,
             frozenset,

--- a/miniagents/promising/ext/frozen.py
+++ b/miniagents/promising/ext/frozen.py
@@ -7,12 +7,13 @@ import json
 from functools import wraps
 from numbers import Number
 from typing import Any, Callable, Optional, Union
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
 from miniagents.promising.sentinels import NO_VALUE
 
-FrozenType = Optional[Union[str, Number, bool, tuple["FrozenType", ...], "Frozen"]]
+FrozenType = Optional[Union[str, Number, bool, UUID, tuple["FrozenType", ...], "Frozen"]]
 
 FROZEN_CLASS_FIELD = "class_"
 
@@ -190,4 +191,4 @@ class Frozen(BaseModel):
 
     @classmethod
     def _allowed_value_types(cls) -> tuple[type[Any], ...]:
-        return type(None), str, Number, bool, tuple, list, dict, Frozen
+        return type(None), str, Number, bool, UUID, tuple, list, dict, Frozen

--- a/miniagents/promising/ext/frozen.py
+++ b/miniagents/promising/ext/frozen.py
@@ -16,25 +16,6 @@ from pydantic import BaseModel, ConfigDict, model_validator
 
 from miniagents.promising.sentinels import NO_VALUE
 
-FrozenType = Optional[
-    Union[
-        str,
-        Number,
-        bool,
-        UUID,
-        datetime,
-        date,
-        time,
-        timedelta,
-        Path,
-        Enum,
-        bytes,
-        frozenset["FrozenType"],
-        tuple["FrozenType", ...],
-        "Frozen",
-    ]
-]
-
 FROZEN_CLASS_FIELD = "class_"
 
 
@@ -78,13 +59,13 @@ class Frozen(BaseModel):
     def __str__(self) -> str:
         return self.as_string
 
-    def get(self, key: str, default: FrozenType = None) -> FrozenType:
+    def get(self, key: str, default: "FrozenType" = None) -> "FrozenType":
         return getattr(self, key, default)
 
-    def __getitem__(self, item: str) -> FrozenType:
+    def __getitem__(self, item: str) -> "FrozenType":
         return getattr(self, item)
 
-    def __contains__(self, key: Union[str, tuple[str, FrozenType]]) -> bool:
+    def __contains__(self, key: Union[str, tuple[str, "FrozenType"]]) -> bool:
         # second part of the condition is for backwards compatibility with the Pydantic itself
         # TODO do we need to maintain a set of keys along with the tuple of keys or there is no benefit ?
         if isinstance(key, str):
@@ -96,7 +77,7 @@ class Frozen(BaseModel):
         return tuple(key for key, _ in self)
 
     @cached_privately
-    def values(self) -> tuple[FrozenType]:
+    def values(self) -> tuple["FrozenType", ...]:
         return tuple(value for _, value in self)
 
     def __len__(self) -> int:
@@ -159,7 +140,7 @@ class Frozen(BaseModel):
             hash_key = hash_key[:40]
         return hash_key
 
-    def as_kwargs(self) -> dict[str, FrozenType]:
+    def as_kwargs(self) -> dict[str, "FrozenType"]:
         """
         Get a dict of field names and values of this Pydantic object which can be used as keyword arguments for
         a function call ("class_" field is excluded, because it wouldn't likely to make sense as a keyword argument).
@@ -186,7 +167,7 @@ class Frozen(BaseModel):
     # noinspection PyNestedDecorators
     @model_validator(mode="before")
     @classmethod
-    def _validate_and_freeze_values(cls, values: dict[str, Any]) -> dict[str, FrozenType]:
+    def _validate_and_freeze_values(cls, values: dict[str, Any]) -> dict[str, "FrozenType"]:
         """
         Recursively make sure that the field values of the object are immutable and of allowed types.
         """
@@ -194,7 +175,7 @@ class Frozen(BaseModel):
         return {key: cls._validate_and_freeze_value(key, value) for key, value in values.items()}
 
     @classmethod
-    def _validate_and_freeze_value(cls, key: str, value: Any) -> FrozenType:
+    def _validate_and_freeze_value(cls, key: str, value: Any) -> "FrozenType":
         """
         Recursively make sure that the field value is immutable and of allowed type.
         """
@@ -230,3 +211,23 @@ class Frozen(BaseModel):
             dict,
             Frozen,
         )
+
+
+FrozenType = Optional[
+    Union[
+        str,
+        Number,
+        bool,
+        UUID,
+        datetime,
+        date,
+        time,
+        timedelta,
+        Path,
+        Enum,
+        bytes,
+        frozenset["FrozenType"],
+        tuple["FrozenType", ...],
+        Frozen,
+    ]
+]

--- a/miniagents/promising/promising.py
+++ b/miniagents/promising/promising.py
@@ -120,6 +120,8 @@ class PromisingContext:
         """
         Add a handler to be called after a promise is resolved.
         """
+        if not callable(handler):
+            raise ValueError("The handler must be a callable.")
         self.on_promise_resolved_handlers.append(handler)
         return handler
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1778,13 +1778,13 @@ jupyter-server = ">=1.1.2"
 
 [[package]]
 name = "jupyter-server"
-version = "2.15.0"
+version = "2.16.0"
 description = "The backend—i.e. core services, APIs, and REST endpoints—to Jupyter web applications."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "jupyter_server-2.15.0-py3-none-any.whl", hash = "sha256:872d989becf83517012ee669f09604aa4a28097c0bd90b2f424310156c2cdae3"},
-    {file = "jupyter_server-2.15.0.tar.gz", hash = "sha256:9d446b8697b4f7337a1b7cdcac40778babdd93ba614b6d68ab1c0c918f1c4084"},
+    {file = "jupyter_server-2.16.0-py3-none-any.whl", hash = "sha256:3d8db5be3bc64403b1c65b400a1d7f4647a5ce743f3b20dbdefe8ddb7b55af9e"},
+    {file = "jupyter_server-2.16.0.tar.gz", hash = "sha256:65d4b44fdf2dcbbdfe0aa1ace4a842d4aaf746a2b7b168134d5aaed35621b7f6"},
 ]
 
 [package.dependencies]
@@ -2722,13 +2722,13 @@ files = [
 
 [[package]]
 name = "openai"
-version = "1.78.0"
+version = "1.78.1"
 description = "The official Python library for the openai API"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "openai-1.78.0-py3-none-any.whl", hash = "sha256:1ade6a48cd323ad8a7715e7e1669bb97a17e1a5b8a916644261aaef4bf284778"},
-    {file = "openai-1.78.0.tar.gz", hash = "sha256:254aef4980688468e96cbddb1f348ed01d274d02c64c6c69b0334bf001fb62b3"},
+    {file = "openai-1.78.1-py3-none-any.whl", hash = "sha256:7368bf147ca499804cc408fe68cdb6866a060f38dec961bbc97b04f9d917907e"},
+    {file = "openai-1.78.1.tar.gz", hash = "sha256:8b26b364531b100df1b961d03560042e5f5be11301d7d49a6cd1a2b9af824dca"},
 ]
 
 [package.dependencies]

--- a/tests/test_frozen.py
+++ b/tests/test_frozen.py
@@ -1,16 +1,59 @@
+# pylint: disable=redefined-outer-name
 """
 Tests for the `Frozen`-based models.
 """
 
 import hashlib
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
+from enum import Enum as PyEnum
+from ipaddress import IPv4Address, IPv6Address
+from pathlib import Path
 from typing import Optional
 from unittest.mock import patch
+from uuid import UUID
 
 import pytest
 from pydantic import ValidationError
 
 from miniagents.promising.ext.frozen import Frozen
 from miniagents.promising.promising import PromisingContext
+
+
+class SampleEnum(PyEnum):
+    OPTION_A = "value_a"
+    OPTION_B = "value_b"
+
+
+@pytest.fixture
+def frozen_with_all_types() -> Frozen:
+    """
+    Provides a Frozen object populated with all allowed immutable types.
+    """
+    return Frozen(
+        field_none=None,
+        field_str="hello world",
+        field_int=123,
+        field_float=45.67,
+        field_bool_true=True,
+        field_bool_false=False,
+        field_uuid=UUID("123e4567-e89b-12d3-a456-426614174000"),
+        field_datetime=datetime(2023, 10, 26, 12, 30, 15),
+        field_date=date(2023, 10, 26),
+        field_time=time(12, 30, 15),
+        field_timedelta=timedelta(days=1, hours=2, minutes=30),
+        field_decimal=Decimal("123.456789"),
+        field_path=Path("/usr/local/bin"),
+        field_ipv4=IPv4Address("192.168.1.1"),
+        field_ipv6=IPv6Address("2001:0db8:85a3:0000:0000:8a2e:0370:7334"),
+        field_enum=SampleEnum.OPTION_A,
+        field_bytes="some bytes".encode("utf-8"),
+        field_frozenset=frozenset([1, "two", True, SampleEnum.OPTION_B, UUID("abcdef01-2345-6789-abcd-ef0123456789")]),
+        field_tuple=("text", 99, False, Path("/tmp")),
+        field_nested_frozen=Frozen(nested_str="nested value", nested_int=789),
+        field_list_to_tuple=[10, "eleven", datetime(2024, 1, 1)],
+        field_dict_to_frozen={"key1": "value1", "key2": 200},
+    )
 
 
 class SampleModel(Frozen):
@@ -125,3 +168,36 @@ async def test_model_hash_key_vs_key_ordering() -> None:
         model2 = Frozen(some_other_field=2, some_field="test")
 
         assert model1.hash_key == model2.hash_key
+
+
+def test_frozen_with_all_types_can_be_created(frozen_with_all_types: Frozen) -> None:
+    """
+    Test that the Frozen object with all types can be created and accessed.
+    """
+    assert frozen_with_all_types.field_none is None
+    assert frozen_with_all_types.field_str == "hello world"
+    assert frozen_with_all_types.field_int == 123
+    assert frozen_with_all_types.field_float == 45.67
+    assert frozen_with_all_types.field_bool_true is True
+    assert frozen_with_all_types.field_bool_false is False
+    assert frozen_with_all_types.field_uuid == UUID("123e4567-e89b-12d3-a456-426614174000")
+    assert frozen_with_all_types.field_datetime == datetime(2023, 10, 26, 12, 30, 15)
+    assert frozen_with_all_types.field_date == date(2023, 10, 26)
+    assert frozen_with_all_types.field_time == time(12, 30, 15)
+    assert frozen_with_all_types.field_timedelta == timedelta(days=1, hours=2, minutes=30)
+    assert frozen_with_all_types.field_decimal == Decimal("123.456789")
+    assert frozen_with_all_types.field_path == Path("/usr/local/bin")
+    assert frozen_with_all_types.field_ipv4 == IPv4Address("192.168.1.1")
+    assert frozen_with_all_types.field_ipv6 == IPv6Address("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+    assert frozen_with_all_types.field_enum == SampleEnum.OPTION_A
+    assert frozen_with_all_types.field_bytes == "some bytes".encode("utf-8")
+    assert frozen_with_all_types.field_frozenset == frozenset(
+        [1, "two", True, SampleEnum.OPTION_B, UUID("abcdef01-2345-6789-abcd-ef0123456789")]
+    )
+    assert frozen_with_all_types.field_tuple == ("text", 99, False, Path("/tmp"))
+    assert frozen_with_all_types.field_nested_frozen == Frozen(nested_str="nested value", nested_int=789)
+    # For fields that are converted, we check the type and content
+    assert isinstance(frozen_with_all_types.field_list_to_tuple, tuple)
+    assert frozen_with_all_types.field_list_to_tuple == (10, "eleven", datetime(2024, 1, 1))
+    assert isinstance(frozen_with_all_types.field_dict_to_frozen, Frozen)
+    assert frozen_with_all_types.field_dict_to_frozen == Frozen(key1="value1", key2=200)

--- a/tests/test_frozen.py
+++ b/tests/test_frozen.py
@@ -7,7 +7,7 @@ import hashlib
 import json
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
-from enum import Enum as PyEnum
+from enum import Enum
 from pathlib import Path
 from typing import Optional
 from unittest.mock import patch
@@ -134,7 +134,7 @@ async def test_model_hash_key_vs_key_ordering() -> None:
         assert model1.hash_key == model2.hash_key
 
 
-class SampleEnum(PyEnum):
+class SampleEnum(Enum):
     OPTION_A = "value_a"
     OPTION_B = "value_b"
 

--- a/tests/test_frozen.py
+++ b/tests/test_frozen.py
@@ -66,7 +66,7 @@ async def test_sample_model_hash_key() -> None:
         # Let's make sure that private instance attributes that were not declared in the model beforehand:
         #  1) are settable despite the model being frozen;
         #  2) do not influence the hash_key.
-        # MiniAgents.on_persist_message event sets a private attribute on Message instances, hence we want to
+        # MiniAgents.on_persist_messages event sets a private attribute on Message instances, hence we want to
         # ensure these properties.
         # pylint: disable=protected-access,attribute-defined-outside-init
         sample._some_private_attribute = "some value"

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,9 +1,15 @@
+# pylint: disable=redefined-outer-name
 """
 Tests for the `Message`-based models.
 """
 
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
+from enum import Enum
 import hashlib
 import json
+from pathlib import Path
+from uuid import UUID
 
 from pydantic import ValidationError
 import pytest
@@ -44,18 +50,18 @@ async def test_message_nesting_vs_hash_key() -> None:
             "class_": "TextMessage",
             "content": "юнікод",
             "content_template": None,
-            "extra_field": (
+            "extra_field": [
                 15,
                 {
                     "class_": "Frozen",
                     "role": "user",
-                    "nested_nested__hash_keys": (
+                    "nested_nested__hash_keys": [
                         "05549eba31f5f800e6f720331d99cb93c62cfaab",
                         "73695a09b7a91de152d65fbea44b4813e97ecd9d",
-                    ),
-                    "nested_nested2__hash_keys": ("73695a09b7a91de152d65fbea44b4813e97ecd9d",),
+                    ],
+                    "nested_nested2__hash_keys": ["73695a09b7a91de152d65fbea44b4813e97ecd9d"],
                 },
-            ),
+            ],
             "extra_node": {
                 "class_": "SpecialNode",
                 "nested_nested__hash_key": "4df48c769ae0669b377dc307f51a8df9cc671cc1",
@@ -235,3 +241,143 @@ def test_strict_message_subclass_is_frozen() -> None:
 
     assert "Instance is frozen" in str(excinfo.value)
     assert message.field1 == "initial_value"
+
+
+class SampleEnum(Enum):
+    OPTION_A = "value_a"
+    OPTION_B = "value_b"
+
+
+@pytest.fixture
+def message_with_all_types() -> Message:
+    """
+    Provides a Message object populated with all allowed immutable types.
+    """
+    # pylint: disable=duplicate-code
+    message = Message(
+        field_none=None,
+        field_str="hello world",
+        field_int=123,
+        field_float=45.67,
+        field_bool_true=True,
+        field_bool_false=False,
+        field_uuid=UUID("123e4567-e89b-12d3-a456-426614174000"),
+        field_datetime=datetime(2023, 10, 26, 12, 30, 15),
+        field_date=date(2023, 10, 26),
+        field_time=time(12, 30, 15),
+        field_timedelta=timedelta(days=1, hours=2, minutes=30),
+        field_decimal=Decimal("123.456789"),
+        field_path=Path("/usr/local/bin"),
+        field_enum=SampleEnum.OPTION_A,
+        field_bytes="some bytes".encode("utf-8"),
+        field_frozenset=frozenset(["two"]),
+        field_tuple=("text", 99, False, Path("/tmp")),
+        field_nested_frozen=Frozen(nested_str="nested value", nested_int=789),
+        field_list_to_tuple=[10, "eleven", datetime(2024, 1, 1)],
+        field_dict_to_frozen={"key1": "value1", "key2": 200},
+    )
+    return message
+
+
+def test_message_with_all_types_can_be_created(message_with_all_types: Message) -> None:
+    """
+    Test that the Message object with all types can be created and accessed.
+    """
+    assert message_with_all_types.field_none is None
+    assert message_with_all_types.field_str == "hello world"
+    assert message_with_all_types.field_int == 123
+    assert message_with_all_types.field_float == 45.67
+    assert message_with_all_types.field_bool_true is True
+    assert message_with_all_types.field_bool_false is False
+    assert message_with_all_types.field_uuid == UUID("123e4567-e89b-12d3-a456-426614174000")
+    assert message_with_all_types.field_datetime == datetime(2023, 10, 26, 12, 30, 15)
+    assert message_with_all_types.field_date == date(2023, 10, 26)
+    assert message_with_all_types.field_time == time(12, 30, 15)
+    assert message_with_all_types.field_timedelta == timedelta(days=1, hours=2, minutes=30)
+    assert message_with_all_types.field_decimal == Decimal("123.456789")
+    assert message_with_all_types.field_path == Path("/usr/local/bin")
+    assert message_with_all_types.field_enum == SampleEnum.OPTION_A
+    assert message_with_all_types.field_bytes == "some bytes".encode("utf-8")
+    assert message_with_all_types.field_frozenset == frozenset(["two"])
+    assert message_with_all_types.field_tuple == ("text", 99, False, Path("/tmp"))
+    assert message_with_all_types.field_nested_frozen == Frozen(nested_str="nested value", nested_int=789)
+    # For fields that are converted, we check the type and content
+    assert isinstance(message_with_all_types.field_list_to_tuple, tuple)
+    assert message_with_all_types.field_list_to_tuple == (10, "eleven", datetime(2024, 1, 1))
+    assert isinstance(message_with_all_types.field_dict_to_frozen, Frozen)
+    assert message_with_all_types.field_dict_to_frozen == Frozen(key1="value1", key2=200)
+
+
+# Expected dictionary content after serialization of `frozen_with_all_types` by `model_dump(mode='json')`
+EXPECTED_SERIALIZED_DICT_VALUES = {
+    "class_": "Message",
+    "field_none": None,
+    "field_str": "hello world",
+    "field_int": 123,
+    "field_float": 45.67,
+    "field_bool_true": True,
+    "field_bool_false": False,
+    "field_uuid": "123e4567-e89b-12d3-a456-426614174000",
+    "field_datetime": "2023-10-26T12:30:15",
+    "field_date": "2023-10-26",
+    "field_time": "12:30:15",
+    "field_timedelta": "P1DT2H30M",
+    "field_decimal": "123.456789",
+    "field_path": "/usr/local/bin",
+    "field_enum": "value_a",
+    "field_bytes": "some bytes",  # Decoded from utf-8 by default in Pydantic's model_dump
+    "field_frozenset": ["two"],  # Updated: frozenset becomes a list with one element
+    "field_tuple": ["text", 99, False, "/tmp"],  # Tuples become lists, elements serialized
+    "field_nested_frozen": {
+        "class_": "Frozen",  # Nested Frozen objects also include 'class_'
+        "nested_str": "nested value",
+        "nested_int": 789,
+    },
+    "field_list_to_tuple": [10, "eleven", "2024-01-01T00:00:00"],  # List elements serialized
+    "field_dict_to_frozen": {
+        "class_": "Frozen",  # Dicts converted to Frozen also include 'class_'
+        "key1": "value1",
+        "key2": 200,
+    },
+}
+
+
+def test_message_serialize(message_with_all_types: Message) -> None:
+    """
+    Test the `serialize()` method of the Message class.
+    """
+    serialized_dict = message_with_all_types.serialize()
+
+    assert isinstance(serialized_dict, dict)
+    assert serialized_dict == EXPECTED_SERIALIZED_DICT_VALUES
+
+
+def test_message_serialized_property(message_with_all_types: Message) -> None:
+    """
+    Test the `serialized` property of the Message class.
+    """
+    serialized_json_str = message_with_all_types.serialized
+    assert isinstance(serialized_json_str, str)
+
+    parsed_data = json.loads(serialized_json_str)
+    assert parsed_data == EXPECTED_SERIALIZED_DICT_VALUES
+
+
+def test_message_full_json_property(message_with_all_types: Message) -> None:
+    """
+    Test the `full_json` property of the Message class.
+    """
+    full_json_str = message_with_all_types.full_json
+    assert isinstance(full_json_str, str)
+    assert str(message_with_all_types) == f"```json\n{full_json_str}\n```"
+
+    parsed_data = json.loads(full_json_str)
+    assert parsed_data == EXPECTED_SERIALIZED_DICT_VALUES
+
+
+async def test_message_hash_key_property(message_with_all_types: Message) -> None:
+    """
+    Test the `hash_key` property of the Message class, ensuring all types are hashable.
+    """
+    async with PromisingContext():
+        assert message_with_all_types.hash_key == "f54fbfdd4d0f4c2e1ff175e992f6776625a38a37"


### PR DESCRIPTION
- More immutable data types are now allowed in Frozen and Message
- Explicit MiniAgents().apersist_messages() introduced to be used in a DB transaction if needed
- The deprecated `mutable_state` was completely removed in favor of `non_freezable_kwargs`