### PR TITLE
Misc fixes and improvements inspired by Spilno

### DIFF
--- a/miniagents/__init__.py
+++ b/miniagents/__init__.py
@@ -11,7 +11,7 @@ from miniagents.messages import (
     Token,
 )
 from miniagents.miniagents import __version__, AgentCall, InteractionContext, MiniAgent, MiniAgents, miniagent
-from miniagents.promising.ext.frozen import Frozen, cached_privately
+from miniagents.promising.ext.frozen import Frozen, FrozenType, cached_privately
 
 __all__ = [
     "__version__",
@@ -19,6 +19,7 @@ __all__ = [
     "cached_privately",
     "ErrorMessage",
     "Frozen",
+    "FrozenType",
     "InteractionContext",
     "Message",
     "MessagePromise",

--- a/miniagents/__init__.py
+++ b/miniagents/__init__.py
@@ -10,12 +10,25 @@ from miniagents.messages import (
     TextToken,
     Token,
 )
-from miniagents.miniagents import __version__, AgentCall, InteractionContext, MiniAgent, MiniAgents, miniagent
+from miniagents.miniagents import (
+    __version__,
+    AgentCall,
+    AgentCallNode,
+    AgentInteractionNode,
+    AgentReplyNode,
+    InteractionContext,
+    MiniAgent,
+    MiniAgents,
+    miniagent,
+)
 from miniagents.promising.ext.frozen import Frozen, FrozenType, cached_privately
 
 __all__ = [
     "__version__",
     "AgentCall",
+    "AgentCallNode",
+    "AgentInteractionNode",
+    "AgentReplyNode",
     "cached_privately",
     "ErrorMessage",
     "Frozen",

--- a/miniagents/miniagents.py
+++ b/miniagents/miniagents.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import contextvars
+import inspect
 import logging
 import re
 import warnings
@@ -97,7 +98,10 @@ class MiniAgents(PromisingContext):
         Add a handler that will be called every time a Message needs to be persisted.
         """
         if not callable(handler):
-            raise ValueError("The handler must be a callable.")
+            raise ValueError("An `on_persist_messages` handler must be a callable.")
+        if not inspect.iscoroutinefunction(handler):
+            raise ValueError("An `on_persist_messages` handler must be async.")
+
         self.on_persist_messages_handlers.append(handler)
         return handler
 

--- a/miniagents/promising/promising.py
+++ b/miniagents/promising/promising.py
@@ -4,6 +4,7 @@ The main class in this module is `StreamedPromise`. See its docstring for more i
 
 import asyncio
 import contextvars
+import inspect
 import logging
 from asyncio import Task
 from contextvars import ContextVar
@@ -121,7 +122,10 @@ class PromisingContext:
         Add a handler to be called after a promise is resolved.
         """
         if not callable(handler):
-            raise ValueError("The handler must be a callable.")
+            raise ValueError("An `on_promise_resolved` handler must be a callable.")
+        if not inspect.iscoroutinefunction(handler):
+            raise ValueError("An `on_promise_resolved` handler must be async.")
+
         self.on_promise_resolved_handlers.append(handler)
         return handler
 
@@ -131,6 +135,8 @@ class PromisingContext:
         `asyncio.create_task()` allows the context to keep track of the child tasks and to wait for them to finish
         before finalizing the context.
         """
+        if not inspect.isawaitable(awaitable):
+            raise TypeError(f"Expected an awaitable, got {type(awaitable).__name__}.")
 
         async def awaitable_wrapper() -> Any:
             # pylint: disable=broad-except

--- a/miniagents/promising/sequence.py
+++ b/miniagents/promising/sequence.py
@@ -65,6 +65,7 @@ class FlatSequence(Generic[IN_co, OUT_co]):
         # TODO we might want to stop processing any more items if an exception is raised and we are not in
         #  "exceptions as messages" mode (or maybe not, I'm not sure)
         async def _process_unordered_piece(zero_or_more_items: OUT_co) -> None:
+            # TODO !!! Does this prevent agents from finishing before all the reply messages are fully resolved ?!!
             try:
                 # let's use `flattener` to convert [potentially] nested sequences into a "flat" sequence
                 async for item in self._flattener(zero_or_more_items):

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -14,8 +14,9 @@ from miniagents.promising.sentinels import NO_VALUE, Sentinel
 
 @pytest.mark.parametrize("start_soon", [False, True, NO_VALUE])
 @pytest.mark.parametrize("reply_out_of_order", [False, True])
+@pytest.mark.parametrize("raw_strings", [False, True])
 async def test_agent_multiple_replies_without_task_switching(
-    start_soon: Union[bool, Sentinel], reply_out_of_order: bool
+    start_soon: Union[bool, Sentinel], reply_out_of_order: bool, raw_strings: bool
 ) -> None:
     """
     Test that an agent can send multiple replies (using both `reply` and `reply_out_of_order` methods) without task
@@ -29,16 +30,21 @@ async def test_agent_multiple_replies_without_task_switching(
         else:
             reply_method = ctx.reply
 
-        reply_method(TextMessage(content="agent 1 msg 1"))
-        reply_method(TextMessage(content="agent 1 msg 2"))
+        def message_factory(content: str) -> TextMessage:
+            if raw_strings:
+                return content
+            return TextMessage(content=content)
+
+        reply_method(message_factory("agent 1 msg 1"))
+        reply_method(message_factory("agent 1 msg 2"))
         reply_method(
             [
-                "agent 1 msg 3",
-                "agent 1 msg 4",
+                message_factory("agent 1 msg 3"),
+                message_factory("agent 1 msg 4"),
             ]
         )
-        reply_method("agent 1 msg 5")
-        reply_method("agent 1 msg 6")
+        reply_method(message_factory("agent 1 msg 5"))
+        reply_method(message_factory("agent 1 msg 6"))
 
     async with MiniAgents():
         replies = await agent1.trigger(start_soon=start_soon)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -8,7 +8,51 @@ from typing import Union
 import pytest
 
 from miniagents import InteractionContext, MiniAgents, miniagent
+from miniagents.messages import TextMessage
 from miniagents.promising.sentinels import NO_VALUE, Sentinel
+
+
+@pytest.mark.parametrize("start_soon", [False, True, NO_VALUE])
+@pytest.mark.parametrize("reply_out_of_order", [False, True])
+async def test_agent_multiple_replies_without_task_switching(
+    start_soon: Union[bool, Sentinel], reply_out_of_order: bool
+) -> None:
+    """
+    Test that an agent can send multiple replies (using both `reply` and `reply_out_of_order` methods) without task
+    switching and all of them are delivered.
+    """
+
+    @miniagent
+    async def agent1(ctx: InteractionContext) -> None:
+        if reply_out_of_order:
+            reply_method = ctx.reply_out_of_order
+        else:
+            reply_method = ctx.reply
+
+        reply_method(TextMessage(content="agent 1 msg 1"))
+        reply_method(TextMessage(content="agent 1 msg 2"))
+        reply_method(
+            [
+                "agent 1 msg 3",
+                "agent 1 msg 4",
+            ]
+        )
+        reply_method("agent 1 msg 5")
+        reply_method("agent 1 msg 6")
+
+    async with MiniAgents():
+        replies = await agent1.trigger(start_soon=start_soon)
+
+    # Even in the case of out-of-order replies, all of them are still delivered in the same order because there is no
+    # real agent concurrency and/or nested agents in this test
+    assert replies == (
+        TextMessage(content="agent 1 msg 1"),
+        TextMessage(content="agent 1 msg 2"),
+        TextMessage(content="agent 1 msg 3"),
+        TextMessage(content="agent 1 msg 4"),
+        TextMessage(content="agent 1 msg 5"),
+        TextMessage(content="agent 1 msg 6"),
+    )
 
 
 @pytest.mark.parametrize("start_soon", [False, True, NO_VALUE])


### PR DESCRIPTION
* Concurrency-proof message persistance
* Possibility to persist messages manually (if batch-mode and transactions are needed)
* A setting to make an agent wait for reply persistence to finish before it finishes
* Safeguards so users don't use synchronous functions as `on_persist_messages` and `on_promise_resolved` event handlers