### PR TITLE
WORK IN PROGRESS: An attempt to enable cancelling of Promises that are still in progress

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -93,7 +93,7 @@ prefer-stubs=no
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.9
+py-version=3.10
 
 # Discover python modules and packages in the file system subtree.
 recursive=no

--- a/miniagents/ext/agents/misc_agents.py
+++ b/miniagents/ext/agents/misc_agents.py
@@ -64,26 +64,28 @@ async def console_output_agent(
     """
     MiniAgent that echoes messages to the console token by token.
     """
-    ctx.reply(ctx.message_promises)  # this is a "transparent" agent - pass the same messages forward
+    try:
+        ctx.reply(ctx.message_promises)  # this is a "transparent" agent - pass the same messages forward
 
-    # TODO should MessageSequencePromise support `cancel()` operation
-    #  (to interrupt whoever is producing it) ?
+        async for msg_promise in ctx.message_promises:
+            resolved_style = getattr(msg_promise.known_beforehand, "console_style", None) or assistant_style
 
-    async for msg_promise in ctx.message_promises:
-        resolved_style = getattr(msg_promise.known_beforehand, "console_style", None) or assistant_style
+            if mention_aliases:
+                agent_alias = (
+                    getattr(msg_promise.known_beforehand, "agent_alias", None)
+                    or getattr(msg_promise.known_beforehand, "role", None)
+                    or default_role
+                )
 
-        if mention_aliases:
-            agent_alias = (
-                getattr(msg_promise.known_beforehand, "agent_alias", None)
-                or getattr(msg_promise.known_beforehand, "role", None)
-                or default_role
-            )
+                print(f"\033[{resolved_style}m{agent_alias.upper()}: \033[0m", end="", flush=True)
 
-            print(f"\033[{resolved_style}m{agent_alias.upper()}: \033[0m", end="", flush=True)
+            async for token in msg_promise:
+                print(f"\033[{resolved_style}m{token}\033[0m", end="", flush=True)
+                print("\n")  # this produces a double newline after a single message
 
-        async for token in msg_promise:
-            print(f"\033[{resolved_style}m{token}\033[0m", end="", flush=True)
-        print("\n")  # this produces a double newline after a single message
+    except KeyboardInterrupt as exc:
+        ctx.message_promises.cancel(str(exc))
+        raise exc
 
 
 @miniagent

--- a/miniagents/messages.py
+++ b/miniagents/messages.py
@@ -464,7 +464,7 @@ class MessageSequence(FlatSequence[MessageType, MessagePromise]):
         Resolve all the messages in the sequence (which also includes collecting all the streamed tokens)
         and return them as a tuple of Message objects.
         """
-        # TODO TODO TODO
+        # TODO [CANCELLATION] Should anything be done here cancellation-wise ?
         # first collect all the message promises
         msg_promises = [msg_promise async for msg_promise in seq_promise]
         # then resolve them all
@@ -563,9 +563,9 @@ class MessageSequencePromise(StreamedPromise[MessagePromise, tuple[Message, ...]
     A promise of a sequence of messages that can be streamed message by message.
     """
 
-    def cancel(self, msg: Optional[str] = None, cancel_messages_too: bool = True) -> bool:
-        # TODO TODO TODO
-        return super().cancel(msg)
+    # def cancel(self, msg: Optional[str] = None, cancel_individual_promises_too: bool = True) -> bool:
+    #     # TODO [CANCELLATION] Cancel message promises already yielded from the sequence too if the flag is True
+    #     return super().cancel(msg)
 
     def as_single_text_promise(self, **kwargs) -> MessagePromise:
         """

--- a/miniagents/messages.py
+++ b/miniagents/messages.py
@@ -464,6 +464,7 @@ class MessageSequence(FlatSequence[MessageType, MessagePromise]):
         Resolve all the messages in the sequence (which also includes collecting all the streamed tokens)
         and return them as a tuple of Message objects.
         """
+        # TODO TODO TODO
         # first collect all the message promises
         msg_promises = [msg_promise async for msg_promise in seq_promise]
         # then resolve them all
@@ -561,6 +562,10 @@ class MessageSequencePromise(StreamedPromise[MessagePromise, tuple[Message, ...]
     """
     A promise of a sequence of messages that can be streamed message by message.
     """
+
+    def cancel(self, msg: Optional[str] = None, cancel_messages_too: bool = True) -> bool:
+        # TODO TODO TODO
+        return super().cancel(msg)
 
     def as_single_text_promise(self, **kwargs) -> MessagePromise:
         """

--- a/miniagents/messages.py
+++ b/miniagents/messages.py
@@ -283,9 +283,11 @@ class MessagePromise(StreamedPromise[Token, Message]):
 
     def __init__(
         self,
+        *,
         start_soon: Union[bool, Sentinel] = NO_VALUE,
         message_token_streamer: Optional[Union[MessageTokenStreamer, "MessageTokenAppender"]] = None,
         prefill_message: Optional[Message] = None,
+        prefill_exception: Optional[BaseException] = None,
         message_class: Optional[type[Message]] = None,
         **known_beforehand,
     ) -> None:
@@ -294,6 +296,8 @@ class MessagePromise(StreamedPromise[Token, Message]):
             raise ValueError(
                 "Cannot provide both 'prefill_message' and 'message_token_streamer'/'known_beforehand' parameters"
             )
+        if prefill_exception is not None and prefill_message is not None:
+            raise ValueError("Cannot provide both 'prefill_exception' and 'prefill_message' parameters")
         if prefill_message is None and message_token_streamer is None:
             raise ValueError("Either 'prefill_message' or 'message_token_streamer' parameter must be provided")
 
@@ -302,7 +306,11 @@ class MessagePromise(StreamedPromise[Token, Message]):
             self.message_class = type(prefill_message)
 
             self._auxiliary_field_collector = None
-            super().__init__(prefill_result=prefill_message, start_soon=False)
+            super().__init__(
+                prefill_result=prefill_message,
+                prefill_exception=prefill_exception,
+                start_soon=False,
+            )
         else:
             if message_class is None:
                 raise ValueError("'message_class' parameter must be provided if 'prefill_message' is not provided")

--- a/miniagents/miniagents.py
+++ b/miniagents/miniagents.py
@@ -6,6 +6,7 @@ import asyncio
 import contextvars
 import inspect
 import logging
+import os
 import re
 import warnings
 from contextvars import ContextVar
@@ -61,7 +62,7 @@ class MiniAgents(PromisingContext):
         on_promise_resolved: Union[PromiseResolvedEventHandler, Iterable[PromiseResolvedEventHandler]] = (),
         errors_as_messages: bool = False,
         error_tracebacks_in_messages: bool = False,
-        log_reduced_tracebacks: bool = True,
+        log_reduced_tracebacks: bool = os.getenv("MINIAGENTS_LOG_REDUCED_TRACEBACKS", "true").lower() == "true",
         await_reply_persistence_before_agent_finish: bool = False,
         logger: Optional[logging.Logger] = None,
         **kwargs,

--- a/miniagents/miniagents.py
+++ b/miniagents/miniagents.py
@@ -79,6 +79,7 @@ class MiniAgents(PromisingContext):
         self.stream_llm_tokens_by_default = stream_llm_tokens_by_default
         self.llm_logger_agent = llm_logger_agent
         self.await_reply_persistence_before_agent_finish = await_reply_persistence_before_agent_finish
+        # TODO check each of the handlers for being a coroutine function
         self.on_persist_messages_handlers: list[PersistMessagesEventHandler] = (
             [on_persist_messages] if callable(on_persist_messages) else list(on_persist_messages)
         )
@@ -117,10 +118,10 @@ class MiniAgents(PromisingContext):
         """
         Add a handler that will be called every time a Message needs to be persisted.
         """
-        if not callable(handler):
-            raise ValueError("An `on_persist_messages` handler must be a callable.")
         if not inspect.iscoroutinefunction(handler):
-            raise ValueError("An `on_persist_messages` handler must be async.")
+            raise ValueError(
+                "An `on_persist_messages` handler must be a coroutine function (defined with `async def`)."
+            )
 
         self.on_persist_messages_handlers.append(handler)
         return handler
@@ -300,12 +301,13 @@ class MiniAgent(Frozen):
         non_freezable_kwargs: Optional[dict[str, Any]] = None,
         **kwargs_to_freeze,
     ) -> None:
-        if not callable(func_or_class):
-            raise ValueError("A `@miniagent` decorated type must be a callable.")
         if not inspect.iscoroutinefunction(func_or_class) and not (
             hasattr(func_or_class, "__call__") and inspect.iscoroutinefunction(func_or_class.__call__)
         ):
-            raise ValueError("A `@miniagent` decorated class or function must be async.")
+            raise ValueError(
+                "A `@miniagent` decorated function or class must be a coroutine function (defined with `async def` "
+                "or have a `__call__` method that is a coroutine function, respectively)."
+            )
 
         if alias is None:
             alias = func_or_class.__name__

--- a/miniagents/miniagents.py
+++ b/miniagents/miniagents.py
@@ -739,7 +739,7 @@ class AgentReplyMessageSequence(MessageSequence):
             )
 
         agent_call_promise = Promise[AgentCallNode](
-            start_soon=True,
+            start_soon=True,  # TODO Try to recall why it is True and explain in a comment
             resolver=_arun_agent,
         )
 

--- a/miniagents/promising/promise_utils.py
+++ b/miniagents/promising/promise_utils.py
@@ -1,0 +1,59 @@
+import asyncio
+import inspect
+from asyncio import Future
+from typing import Any, Optional, Union
+
+
+async def acancel_async_object(
+    async_object: Any, msg: Optional[Union[str, asyncio.CancelledError]] = None, raise_if_not_cancellable: bool = True
+) -> Optional[asyncio.CancelledError]:
+    """
+    Handle cancellation of async futures, generators, StreamAppenders, etc.
+
+    Args:
+        async_object: The async object to cancel (could be a future, a generator, a StreamAppender, etc.)
+        msg: The message to put into the `CancelledError` instance, or a `CancelledError` instance itself to use as is
+        raise_if_not_cancellable: Whether to raise an error if the async object does not support cancellation
+
+    Returns:
+        The `CancelledError` instance that was used to cancel the async object, or `None` if the async object does not
+        support cancellation.
+    """
+    # pylint: disable=import-outside-toplevel,cyclic-import
+    from miniagents.promising.promising import StreamAppender
+
+    cancelled_error = prepare_cancelled_error(msg)
+    cancelled = False
+
+    if inspect.isasyncgen(async_object):
+        try:
+            await async_object.athrow(cancelled_error)
+        except type(cancelled_error):
+            pass
+        cancelled = True
+
+    if isinstance(async_object, Future):
+        async_object.cancel(str(cancelled_error))
+        cancelled = True
+
+    if isinstance(async_object, StreamAppender):
+        async_object.cancel(cancelled_error)
+        cancelled = True
+
+    if not cancelled and raise_if_not_cancellable:
+        raise RuntimeError(f"Object {async_object} does not support cancellation")
+
+    return cancelled_error if cancelled else None
+
+
+def prepare_cancelled_error(
+    msg: Optional[Union[str, asyncio.CancelledError]] = None,
+) -> asyncio.CancelledError:
+    """
+    Prepare a cancelled error to be raised. If `msg` is already a `CancelledError`, return it as is.
+    """
+    if msg is None:
+        return asyncio.CancelledError()
+    if isinstance(msg, asyncio.CancelledError):
+        return msg
+    return asyncio.CancelledError(msg)

--- a/miniagents/promising/promising.py
+++ b/miniagents/promising/promising.py
@@ -449,9 +449,17 @@ class StreamedPromise(Promise[WHOLE_co], Generic[PIECE_co, WHOLE_co]):
 
         try:
             if self.cancelled():
-                if not hasattr(self._astreamer_aiter, "athrow"):
-                    raise self._make_cancelled_error()
-                self._astreamer_aiter.athrow(self._make_cancelled_error())
+                cancelled_error = self._make_cancelled_error()
+
+                if isinstance(self._astreamer_aiter, StreamAppender):
+                    # The error WILL NOT be raised from here, but it will be explicitly raised after the if-elif block
+                    self._astreamer_aiter.cancel(cancelled_error)
+                elif inspect.isasyncgen(self._astreamer_aiter):
+                    # The error WILL be raised from here implicitly (`athrow` raises the error both, here and in the
+                    # generator)
+                    self._astreamer_aiter.athrow(cancelled_error)
+
+                raise cancelled_error
 
             return await anext(self._astreamer_aiter)
 
@@ -561,6 +569,7 @@ class StreamAppender(AsyncIterator[PIECE_co], Generic[PIECE_co]):
         self._queue = asyncio.Queue()
         self._append_was_open = False
         self._append_closed = False
+        self._cancelled_error: Optional[asyncio.CancelledError] = None
 
     @property
     def was_open(self) -> bool:
@@ -605,6 +614,8 @@ class StreamAppender(AsyncIterator[PIECE_co], Generic[PIECE_co]):
                 "(or call `open()` and `close()` manually)."
             )
         if self._append_closed:
+            if self._cancelled_error:
+                raise self._cancelled_error
             raise AppenderClosedError(f"The {type(self).__name__} has already been closed for appending.")
         self._queue.put_nowait(piece)
         return self
@@ -623,6 +634,32 @@ class StreamAppender(AsyncIterator[PIECE_co], Generic[PIECE_co]):
             raise AppenderClosedError(f"Once closed, the {type(self).__name__} cannot be opened again.")
         self._append_was_open = True
         return self
+
+    def cancel(self, msg: Optional[Union[str, asyncio.CancelledError]] = None) -> bool:
+        """
+        Cancel the streamer by appending a CancelledError to the queue and immediately closing it.
+
+        Args:
+            msg: Optional message to include in the CancelledError.
+                 If an instance of asyncio.CancelledError is provided instead of a string, it is used as is.
+                 If not provided at all, a CancelledError without a message is constructed.
+
+        Returns:
+            True if the appender was successfully cancelled, False if it was already closed
+        """
+        if self._append_closed:
+            return False
+
+        if msg is None:
+            self._cancelled_error = asyncio.CancelledError()
+        elif isinstance(msg, asyncio.CancelledError):
+            self._cancelled_error = msg
+        else:
+            self._cancelled_error = asyncio.CancelledError(msg)
+
+        self.close(self._cancelled_error)
+
+        return True
 
     def close(self, exc_value: Optional[BaseException] = None) -> bool:
         """

--- a/miniagents/promising/promising.py
+++ b/miniagents/promising/promising.py
@@ -282,6 +282,8 @@ class Promise(Future, Generic[T_co]):
                 self.set_exception(prefill_exception)
             self._trigger_promise_resolved_event()
 
+    # TODO def cancel(self, msg: Optional[str] = None) -> bool: ...
+
     async def _aresolver(self) -> T_co:  # pylint: disable=method-hidden
         raise FunctionNotProvidedError(
             "The `resolver` function should be provided either via the constructor "

--- a/miniagents/promising/promising.py
+++ b/miniagents/promising/promising.py
@@ -425,6 +425,10 @@ class StreamedPromise(Promise[WHOLE_co], Generic[PIECE_co, WHOLE_co]):
         # pylint: disable=broad-except
         if self._astreamer_aiter is None:
             try:
+                if self.cancelled():
+                    # Let's not even try to instantiate the streamer iterator if the promise is already cancelled
+                    raise self._make_cancelled_error()
+
                 self._astreamer_aiter = self._astreamer()
                 # noinspection PyUnresolvedReferences
                 if (
@@ -432,7 +436,9 @@ class StreamedPromise(Promise[WHOLE_co], Generic[PIECE_co, WHOLE_co]):
                     or not getattr(self._astreamer_aiter, "__anext__", None)
                     or not callable(self._astreamer_aiter.__anext__)
                 ):
-                    raise TypeError(f"The streamer must return an async iterator, but got {self._astreamer_aiter}")
+                    raise TypeError(
+                        f"The streamer must return an async iterator, got {type(self._astreamer_aiter)} instead"
+                    )
             except BaseException as exc:
                 self._promising_context.logger.debug(
                     "An error occurred while instantiating a streamer for a StreamedPromise", exc_info=True

--- a/miniagents/promising/promising.py
+++ b/miniagents/promising/promising.py
@@ -61,6 +61,7 @@ class PromisingContext:
     ) -> None:
         self.parent_ctx = self._current.get()
 
+        # TODO check each of the handlers for being a coroutine function
         self.on_promise_resolved_handlers: list[PromiseResolvedEventHandler] = (
             [on_promise_resolved] if callable(on_promise_resolved) else [*on_promise_resolved]
         )
@@ -122,10 +123,10 @@ class PromisingContext:
         """
         Add a handler to be called after a promise is resolved.
         """
-        if not callable(handler):
-            raise ValueError("An `on_promise_resolved` handler must be a callable.")
         if not inspect.iscoroutinefunction(handler):
-            raise ValueError("An `on_promise_resolved` handler must be async.")
+            raise ValueError(
+                "An `on_promise_resolved` handler must be a coroutine function (defined with `async def`)."
+            )
 
         self.on_promise_resolved_handlers.append(handler)
         return handler
@@ -431,11 +432,7 @@ class StreamedPromise(Promise[WHOLE_co], Generic[PIECE_co, WHOLE_co]):
 
                 self._astreamer_aiter = self._astreamer()
                 # noinspection PyUnresolvedReferences
-                if (
-                    not self._astreamer_aiter
-                    or not getattr(self._astreamer_aiter, "__anext__", None)
-                    or not callable(self._astreamer_aiter.__anext__)
-                ):
+                if not self._astreamer_aiter or not getattr(self._astreamer_aiter, "__anext__", None):
                     raise TypeError(
                         f"The streamer must return an async iterator, got {type(self._astreamer_aiter)} instead"
                     )
@@ -452,8 +449,12 @@ class StreamedPromise(Promise[WHOLE_co], Generic[PIECE_co, WHOLE_co]):
 
         try:
             if self.cancelled():
+                if not hasattr(self._astreamer_aiter, "athrow"):
+                    raise self._make_cancelled_error()
                 self._astreamer_aiter.athrow(self._make_cancelled_error())
+
             return await anext(self._astreamer_aiter)
+
         except BaseException as exc:
             if not isinstance(exc, StopAsyncIteration):
                 self._promising_context.logger.debug(

--- a/miniagents/promising/promising.py
+++ b/miniagents/promising/promising.py
@@ -241,9 +241,6 @@ class Promise(Future, Generic[T_co]):
       (closer to task than to future).
     """
 
-    # TODO Make it extend asyncio.Future, but do it manually
-    # TODO Try to leverage from properties of asyncio.Task as much as possible
-
     def __init__(
         self,
         *,
@@ -282,7 +279,10 @@ class Promise(Future, Generic[T_co]):
                 self.set_exception(prefill_exception)
             self._trigger_promise_resolved_event()
 
-    # TODO def cancel(self, msg: Optional[str] = None) -> bool: ...
+    def cancel(self, msg: Optional[str] = None) -> bool:
+        if self._task:
+            self._task.cancel(msg)
+        return super().cancel(msg)
 
     async def _aresolver(self) -> T_co:  # pylint: disable=method-hidden
         raise FunctionNotProvidedError(

--- a/miniagents/promising/promising.py
+++ b/miniagents/promising/promising.py
@@ -7,6 +7,7 @@ import contextvars
 import inspect
 import logging
 from asyncio import AbstractEventLoop, Future, Task
+from collections import abc
 from contextvars import ContextVar
 from functools import partial
 from types import TracebackType
@@ -26,6 +27,7 @@ from miniagents.promising.promise_typing import (
     T_co,
     WHOLE_co,
 )
+from miniagents.promising.promise_utils import acancel_async_object, prepare_cancelled_error
 from miniagents.promising.sentinels import END_OF_QUEUE, FAILED, NO_VALUE, Sentinel
 
 
@@ -131,6 +133,9 @@ class PromisingContext:
         self.on_promise_resolved_handlers.append(handler)
         return handler
 
+    # # TODO [CANCELLATION] Come up with a way of tracking the "causality" of the spawned tasks
+    # async_tracebacks = contextvars.ContextVar("async_tracebacks", default=())
+
     def start_soon(self, awaitable: Awaitable, suppress_errors: bool = True) -> Task:
         """
         Schedule a task in the current context. "Scheduling" a task this way instead of just creating it with
@@ -157,7 +162,28 @@ class PromisingContext:
             finally:
                 self.child_tasks.remove(task)
 
+        # # TODO [CANCELLATION] Come up with a way of tracking the "causality" of the spawned tasks
+        # task_name = awaitable.__name__
+        # if hasattr(awaitable, "__self__"):
+        #     # Instance method or class method
+        #     if hasattr(awaitable.__self__, "__class__"):
+        #         if isinstance(awaitable.__self__, type):
+        #             # Class method - __self__ is the class itself
+        #             task_name = f"{awaitable.__self__.__name__}.{task_name}"
+        #         else:
+        #             # Instance method - __self__ is an instance
+        #             task_name = f"{awaitable.__self__.__class__.__name__}.{task_name}"
+        # elif hasattr(awaitable, "__qualname__") and "." in awaitable.__qualname__:
+        #     # Static method or nested function
+        #     task_name = awaitable.__qualname__
+
+        # current_tracebacks = self.async_tracebacks.get()
+        # current_tracebacks = current_tracebacks + ("".join(traceback.format_stack()),)
+        # self.async_tracebacks.set(current_tracebacks)
+        # task = asyncio.create_task(awaitable_wrapper(), name=task_name)
+        # task.async_tracebacks = current_tracebacks
         task = asyncio.create_task(awaitable_wrapper())
+
         self.child_tasks.add(task)
         return task
 
@@ -281,8 +307,9 @@ class Promise(Future, Generic[T_co]):
             self._trigger_promise_resolved_event()
 
     def cancel(self, msg: Optional[str] = None) -> bool:
-        if self._task:
-            self._task.cancel(msg)
+        task = self._task
+        if task:
+            task.cancel(msg)
         return super().cancel(msg)
 
     async def _aresolver(self) -> T_co:  # pylint: disable=method-hidden
@@ -417,6 +444,8 @@ class StreamedPromise(Promise[WHOLE_co], Generic[PIECE_co, WHOLE_co]):
 
     async def _aconsume_the_stream(self) -> None:
         while True:
+            if self.cancelled():
+                break
             piece = await self._astreamer_aiter_anext()
             self._queue.put_nowait(piece)
             if isinstance(piece, StopAsyncIteration):
@@ -450,15 +479,8 @@ class StreamedPromise(Promise[WHOLE_co], Generic[PIECE_co, WHOLE_co]):
         try:
             if self.cancelled():
                 cancelled_error = self._make_cancelled_error()
-
-                if isinstance(self._astreamer_aiter, StreamAppender):
-                    # The error WILL NOT be raised from here, but it will be explicitly raised after the if-elif block
-                    self._astreamer_aiter.cancel(cancelled_error)
-                elif inspect.isasyncgen(self._astreamer_aiter):
-                    # The error WILL be raised from here implicitly (`athrow` raises the error both, here and in the
-                    # generator)
-                    self._astreamer_aiter.athrow(cancelled_error)
-
+                # TODO [CANCELLATION] raise_if_not_cancellable=False ?
+                await acancel_async_object(self._astreamer_aiter, msg=cancelled_error)
                 raise cancelled_error
 
             return await anext(self._astreamer_aiter)
@@ -478,7 +500,7 @@ class StreamedPromise(Promise[WHOLE_co], Generic[PIECE_co, WHOLE_co]):
             return exc
 
 
-class _StreamReplayIterator(AsyncIterator[PIECE_co]):
+class _StreamReplayIterator(abc.AsyncIterator[PIECE_co]):
     """
     The pieces that have already been "produced" are stored in the `_pieces_so_far` attribute of the parent
     `StreamedPromise`. The `_StreamReplayIterator` first yields the pieces from `_pieces_so_far`, and then it
@@ -531,7 +553,7 @@ class _StreamReplayIterator(AsyncIterator[PIECE_co]):
         return piece
 
 
-class StreamAppender(AsyncIterator[PIECE_co], Generic[PIECE_co]):
+class StreamAppender(abc.AsyncIterator[PIECE_co], Generic[PIECE_co]):
     """
     This is a special kind of `streamer` that can be fed into `StreamedPromise` constructor. Objects of this class
     implement the context manager protocol and an `append()` method, which allows for passing such an object into
@@ -650,13 +672,7 @@ class StreamAppender(AsyncIterator[PIECE_co], Generic[PIECE_co]):
         if self._append_closed:
             return False
 
-        if msg is None:
-            self._cancelled_error = asyncio.CancelledError()
-        elif isinstance(msg, asyncio.CancelledError):
-            self._cancelled_error = msg
-        else:
-            self._cancelled_error = asyncio.CancelledError(msg)
-
+        self._cancelled_error = prepare_cancelled_error(msg)
         self.close(self._cancelled_error)
 
         return True
@@ -715,9 +731,6 @@ class StreamAppender(AsyncIterator[PIECE_co], Generic[PIECE_co]):
             raise StopAsyncIteration()
 
         return piece
-
-    def __aiter__(self) -> AsyncIterator[PIECE_co]:
-        return self
 
     def __call__(self, *args, **kwargs) -> AsyncIterator[PIECE_co]:
         return aiter(self)

--- a/miniagents/promising/promising.py
+++ b/miniagents/promising/promising.py
@@ -266,7 +266,7 @@ class Promise(Future, Generic[T_co]):
         if resolver:
             self._aresolver = partial(resolver, self)
 
-        if prefill_result is NO_VALUE:
+        if prefill_result is NO_VALUE and prefill_exception is None:
             # NO_VALUE is used because `None` is also a legitimate value
             if start_soon:
                 self._task = self._promising_context.start_soon(self._aresolve())
@@ -333,6 +333,7 @@ class StreamedPromise(Promise[WHOLE_co], Generic[PIECE_co, WHOLE_co]):
         resolver: A callable that takes an async iterable of pieces and returns the whole value
                  ("packages" the pieces).
         prefill_result: Optional pre-computed result for the promise. Cannot be used with resolver.
+        prefill_exception: Optional pre-computed exception for the promise. Cannot be used with resolver.
         start_soon: If True, the promise will start producing pieces immediately when created, regardless of
                    when consumers start iterating over the promise. If False, pieces will be produced on demand
                    only when the first consumer starts iterating. Defaults to the parent context's
@@ -354,18 +355,22 @@ class StreamedPromise(Promise[WHOLE_co], Generic[PIECE_co, WHOLE_co]):
         prefill_pieces: Union[Optional[Iterable[PIECE_co]], Sentinel] = NO_VALUE,
         resolver: Optional[PromiseResolver[T_co]] = None,
         prefill_result: Union[Optional[T_co], Sentinel] = NO_VALUE,
+        prefill_exception: Optional[BaseException] = None,
         start_soon: Union[bool, Sentinel] = NO_VALUE,
     ) -> None:
         if streamer is not None and prefill_pieces is not NO_VALUE:
             raise ValueError("Cannot provide both 'streamer' and 'prefill_pieces' parameters")
+        if prefill_exception is not None and prefill_result is not NO_VALUE:
+            raise ValueError("Cannot provide both 'prefill_exception' and 'prefill_result' parameters")
 
         super().__init__(
             start_soon=start_soon,
             resolver=resolver,
             prefill_result=prefill_result,
+            prefill_exception=prefill_exception,
         )
-        # ATTENTION !!! DO NOT use `start_soon` directly, USE `self._start_soon` instead !!!
-        # Unlike the former, the parent class initializes the latter with the default value if it is None.
+        # Let's not use `start_soon` directly, and use `self._start_soon` instead. Unlike the former, the parent class
+        # initializes the latter with the default value if it is NO_VALUE.
         del start_soon
 
         if streamer:

--- a/miniagents/promising/promising.py
+++ b/miniagents/promising/promising.py
@@ -360,8 +360,6 @@ class StreamedPromise(Promise[WHOLE_co], Generic[PIECE_co, WHOLE_co]):
     ) -> None:
         if streamer is not None and prefill_pieces is not NO_VALUE:
             raise ValueError("Cannot provide both 'streamer' and 'prefill_pieces' parameters")
-        if prefill_exception is not None and prefill_result is not NO_VALUE:
-            raise ValueError("Cannot provide both 'prefill_exception' and 'prefill_result' parameters")
 
         super().__init__(
             start_soon=start_soon,
@@ -447,6 +445,8 @@ class StreamedPromise(Promise[WHOLE_co], Generic[PIECE_co, WHOLE_co]):
             return StopAsyncIteration()
 
         try:
+            if self.cancelled():
+                self._astreamer_aiter.athrow(self._make_cancelled_error())
             return await anext(self._astreamer_aiter)
         except BaseException as exc:
             if not isinstance(exc, StopAsyncIteration):

--- a/miniagents/promising/sequence.py
+++ b/miniagents/promising/sequence.py
@@ -99,7 +99,7 @@ class FlatSequence(Generic[IN_co, OUT_co]):
             self._queue.put_nowait(END_OF_QUEUE)
 
     async def _astreamer(self, _) -> AsyncIterator[OUT_co]:
-        # TODO TODO TODO
+        # TODO TODO TODO TODO TODO TODO
         normal_stream_finished = self._normal_streamer_aiter is None  # will always be `False`, though
         unordered_stream_finished = self._unordered_streamer_aiter is None
 

--- a/miniagents/promising/sequence.py
+++ b/miniagents/promising/sequence.py
@@ -1,13 +1,10 @@
-"""
-The main class in this module is `FlatSequence`. See its docstring for more information.
-"""
-
 import asyncio
 from functools import partial
 from typing import AsyncIterator, Generic, Optional, Union
 
 from miniagents.promising.errors import FunctionNotProvidedError
 from miniagents.promising.promise_typing import IN_co, OUT_co, PromiseStreamer, SequenceFlattener
+from miniagents.promising.promise_utils import acancel_async_object
 from miniagents.promising.promising import PromisingContext, StreamedPromise
 from miniagents.promising.sentinels import END_OF_QUEUE, END_OF_UNORDERED_QUEUE, NO_VALUE, Sentinel
 
@@ -56,8 +53,6 @@ class FlatSequence(Generic[IN_co, OUT_co]):
 
     async def _amerge_streams(self) -> None:
         # TODO a detailed docstring is crucial for this private method
-        # TODO we might want to stop processing any more items if an exception is raised and we are not in
-        #  "exceptions as messages" mode (or maybe not, I'm not sure)
         async def _process_unordered_piece(zero_or_more_items: OUT_co) -> None:
             # TODO !!! Does this prevent agents from finishing before all the reply messages are fully resolved ?!!
             try:
@@ -68,8 +63,8 @@ class FlatSequence(Generic[IN_co, OUT_co]):
                 self._queue.put_nowait(exc)
 
         async def _go_over_unordered_stream() -> None:
+            subtasks = []
             try:
-                subtasks = []
                 async for zero_or_more_items in self._unordered_streamer_aiter:  # pylint: disable=not-an-iterable
                     subtask = self._promising_context.start_soon(_process_unordered_piece(zero_or_more_items))
                     subtasks.append(subtask)
@@ -78,13 +73,16 @@ class FlatSequence(Generic[IN_co, OUT_co]):
                 # priority stream is finished
                 await self._promising_context.agather(*subtasks)
             except BaseException as exc:  # pylint: disable=broad-except
+                for subtask in subtasks:
+                    subtask.cancel(str(exc))
                 self._queue.put_nowait(exc)
             finally:
                 self._queue.put_nowait(END_OF_UNORDERED_QUEUE)
 
+        unordered_stream_task = None
         try:
             if self._unordered_streamer_aiter is not None:
-                self._promising_context.start_soon(_go_over_unordered_stream())
+                unordered_stream_task = self._promising_context.start_soon(_go_over_unordered_stream())
 
             async for zero_or_more_items in self._normal_streamer_aiter:
                 try:
@@ -94,29 +92,50 @@ class FlatSequence(Generic[IN_co, OUT_co]):
                 except BaseException as exc:  # pylint: disable=broad-except
                     self._queue.put_nowait(exc)
         except BaseException as exc:  # pylint: disable=broad-except
+            if unordered_stream_task is not None:
+                unordered_stream_task.cancel(str(exc))
             self._queue.put_nowait(exc)
         finally:
             self._queue.put_nowait(END_OF_QUEUE)
 
     async def _astreamer(self, _) -> AsyncIterator[OUT_co]:
-        # TODO TODO TODO TODO TODO TODO
         normal_stream_finished = self._normal_streamer_aiter is None  # will always be `False`, though
         unordered_stream_finished = self._unordered_streamer_aiter is None
 
-        self._promising_context.start_soon(self._amerge_streams())
-        while True:
-            item = await self._queue.get()
-            if item is END_OF_UNORDERED_QUEUE:
-                unordered_stream_finished = True
-            elif item is END_OF_QUEUE:
-                normal_stream_finished = True
-            else:
-                yield item
+        merge_streams_task = self._promising_context.start_soon(self._amerge_streams())
+        try:
+            while True:
+                item = await self._queue.get()
+                if item is END_OF_UNORDERED_QUEUE:
+                    unordered_stream_finished = True
+                elif item is END_OF_QUEUE:
+                    normal_stream_finished = True
+                else:
+                    yield item
 
-            if normal_stream_finished and unordered_stream_finished:
-                return
+                if normal_stream_finished and unordered_stream_finished:
+                    return
+
+        except (asyncio.CancelledError, GeneratorExit) as exc:
+            error_msg = str(exc)
+            if isinstance(exc, asyncio.CancelledError):
+                cancelled_error = exc
+            else:
+                # It's not a `CancelledError`, let's only use the message
+                cancelled_error = error_msg
+
+            merge_streams_task.cancel(error_msg)
+            # pylint: disable=broad-except
+            try:
+                if not normal_stream_finished:
+                    # TODO [CANCELLATION] raise_if_not_cancellable=False ?
+                    await acancel_async_object(self._normal_streamer_aiter, msg=cancelled_error)
+            finally:
+                if not unordered_stream_finished:
+                    # TODO [CANCELLATION] raise_if_not_cancellable=False ?
+                    await acancel_async_object(self._unordered_streamer_aiter, msg=cancelled_error)
 
     async def _aresolver(self, seq_promise: StreamedPromise[OUT_co, tuple[OUT_co, ...]]) -> tuple[OUT_co, ...]:
-        # TODO TODO TODO
+        # TODO [CANCELLATION] Should anything be done here cancellation-wise ?
         # pylint: disable=consider-using-generator
         return tuple([item async for item in seq_promise])

--- a/miniagents/promising/sequence.py
+++ b/miniagents/promising/sequence.py
@@ -38,18 +38,12 @@ class FlatSequence(Generic[IN_co, OUT_co]):
 
         self._queue = asyncio.Queue()
 
-        # # TODO why did we need this promise ? it didn't seem to accomplish anything
-        # self._input_promise = StreamedPromise(
-        #     streamer=self._astreamer,
-        #     resolver=lambda _: None,
-        #     start_soon=False,
-        # )
         # TODO should I really pass `self` here ? it is not of type `StreamedPromiseBound` ? why pass anything at all ?
         self._normal_streamer_aiter = normal_streamer(self)
         self._unordered_streamer_aiter = unordered_streamer(self) if unordered_streamer else None
 
         self.sequence_promise = sequence_promise_class(
-            streamer=self._astreamer,  # self._input_promise,
+            streamer=self._astreamer,
             resolver=self._aresolver,
             start_soon=self._start_soon,
         )
@@ -105,6 +99,7 @@ class FlatSequence(Generic[IN_co, OUT_co]):
             self._queue.put_nowait(END_OF_QUEUE)
 
     async def _astreamer(self, _) -> AsyncIterator[OUT_co]:
+        # TODO TODO TODO
         normal_stream_finished = self._normal_streamer_aiter is None  # will always be `False`, though
         unordered_stream_finished = self._unordered_streamer_aiter is None
 
@@ -122,5 +117,6 @@ class FlatSequence(Generic[IN_co, OUT_co]):
                 return
 
     async def _aresolver(self, seq_promise: StreamedPromise[OUT_co, tuple[OUT_co, ...]]) -> tuple[OUT_co, ...]:
+        # TODO TODO TODO
         # pylint: disable=consider-using-generator
         return tuple([item async for item in seq_promise])

--- a/miniagents/utils.py
+++ b/miniagents/utils.py
@@ -201,6 +201,12 @@ class MiniAgentsLogFormatter(logging.Formatter):
                 "ATTENTION! Some parts of the traceback above are omitted for readability.\n"
                 "Use `MiniAgents(log_reduced_tracebacks=False)` to see the full traceback.\n"
             )
+        else:
+            lines.append(
+                "\n"
+                "ATTENTION! All the traceback lines are shown (including those from `miniagents` library).\n"
+                "Use `MiniAgents(log_reduced_tracebacks=True)` to only show the lines from the scripts you wrote.\n"
+            )
 
         # Add the agent trace if enabled
         if self.include_agent_trace:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "pytest",
     "pytest-asyncio",
     "pytest-cov",
+    "pytest-dotenv",
     "python-dotenv",
     "selenium",
 ]

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -11,29 +11,41 @@ from miniagents import miniagent, InteractionContext, Message, MiniAgents, TextM
 from miniagents.promising.sentinels import NO_VALUE, Sentinel
 
 
-@pytest.mark.skip(reason="TODO TODO TODO")  # TODO TODO TODO
-async def test_cancel_agent() -> None:
-    steps = []
+@pytest.mark.skip(reason="TODO [CANCELLATION] Unskip this test when cancellation fully works")
+async def test_cancel_agent_immediately() -> None:
+    agent1_ran = False
 
     @miniagent
-    async def agent1(ctx: InteractionContext) -> None:
-        steps.append("before first reply")
-        ctx.reply("first reply")
-        steps.append("after first reply")
-
-        await asyncio.sleep(0.1)
-
-        steps.append("before second reply")
-        ctx.reply("second reply")
-        steps.append("after second reply")
+    async def agent1(_: InteractionContext) -> None:
+        nonlocal agent1_ran
+        agent1_ran = True
 
     async with MiniAgents():
         reply_sequence = agent1.trigger()
         reply_sequence.cancel()
-        replies = await reply_sequence
+        await reply_sequence
 
-    assert not replies
-    assert not steps
+    assert not agent1_ran
+
+
+@pytest.mark.skip(reason="TODO [CANCELLATION] Unskip this test when cancellation fully works")
+async def test_cancel_agent_with_delay() -> None:
+    agent_steps = []
+
+    @miniagent
+    async def agent1(_: InteractionContext) -> None:
+        agent_steps.append("agent1 - start")
+        await asyncio.sleep(0.2)
+        agent_steps.append("agent1 - end")
+
+    async with MiniAgents(start_everything_soon_by_default=True):
+        reply_sequence = agent1.trigger()
+        await asyncio.sleep(0.1)
+        reply_sequence.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await reply_sequence
+
+    assert agent_steps == ["agent1 - start"]
 
 
 @pytest.mark.parametrize("start_soon", [False, True, NO_VALUE])

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -26,13 +26,13 @@ async def test_cancel_agent() -> None:
         ctx.reply("second reply")
         steps.append("after second reply")
 
-    # async with MiniAgents():
-    #     reply_sequence = agent1.trigger()
-    #     reply_sequence.cancel()
-    #     replies = await reply_sequence
+    async with MiniAgents():
+        reply_sequence = agent1.trigger()
+        reply_sequence.cancel()
+        replies = await reply_sequence
 
-    # assert not replies
-    # assert not steps
+    assert not replies
+    assert not steps
 
 
 @pytest.mark.parametrize("start_soon", [False, True, NO_VALUE])

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -11,6 +11,30 @@ from miniagents import miniagent, InteractionContext, Message, MiniAgents, TextM
 from miniagents.promising.sentinels import NO_VALUE, Sentinel
 
 
+async def test_cancel_agent() -> None:
+    steps = []
+
+    @miniagent
+    async def agent1(ctx: InteractionContext) -> None:
+        steps.append("before first reply")
+        ctx.reply("first reply")
+        steps.append("after first reply")
+
+        await asyncio.sleep(0.1)
+
+        steps.append("before second reply")
+        ctx.reply("second reply")
+        steps.append("after second reply")
+
+    async with MiniAgents():
+        reply_sequence = agent1.trigger()
+        reply_sequence.cancel()
+        replies = await reply_sequence
+
+    assert not replies
+    assert not steps
+
+
 @pytest.mark.parametrize("start_soon", [False, True, NO_VALUE])
 @pytest.mark.parametrize("reply_out_of_order", [False, True])
 @pytest.mark.parametrize("raw_strings", [False, True])

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -26,13 +26,13 @@ async def test_cancel_agent() -> None:
         ctx.reply("second reply")
         steps.append("after second reply")
 
-    async with MiniAgents():
-        reply_sequence = agent1.trigger()
-        reply_sequence.cancel()
-        replies = await reply_sequence
+    # async with MiniAgents():
+    #     reply_sequence = agent1.trigger()
+    #     reply_sequence.cancel()
+    #     replies = await reply_sequence
 
-    assert not replies
-    assert not steps
+    # assert not replies
+    # assert not steps
 
 
 @pytest.mark.parametrize("start_soon", [False, True, NO_VALUE])

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -11,6 +11,7 @@ from miniagents import miniagent, InteractionContext, Message, MiniAgents, TextM
 from miniagents.promising.sentinels import NO_VALUE, Sentinel
 
 
+@pytest.mark.skip(reason="TODO TODO TODO")  # TODO TODO TODO
 async def test_cancel_agent() -> None:
     steps = []
 

--- a/tests/test_llm_integrations.py
+++ b/tests/test_llm_integrations.py
@@ -6,13 +6,8 @@ Test the LLM agents.
 from typing import Callable
 
 import pytest
-from dotenv import load_dotenv
 
 from miniagents import Message, MiniAgent, MiniAgents, TextMessage
-
-load_dotenv()
-
-# pylint: disable=wrong-import-position
 from miniagents.ext.llms import AnthropicAgent, OpenAIAgent
 
 

--- a/tests/test_promise.py
+++ b/tests/test_promise.py
@@ -79,6 +79,10 @@ async def test_stream_replay_iterator_exception(start_soon: bool) -> None:
         # iterate over the stream again
         await iterate_over_promise()
 
+        # Let's get rid of the "exception was never retrieved" error from the console output
+        with pytest.raises(ValueError):
+            await streamed_promise
+
 
 async def _async_streamer_but_not_generator(_):
     return  # not a generator

--- a/uv.lock
+++ b/uv.lock
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.57.1"
+version = "0.58.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -149,9 +149,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/75/6261a1a8d92aed47e27d2fcfb3a411af73b1435e6ae1186da02b760565d0/anthropic-0.57.1.tar.gz", hash = "sha256:7815dd92245a70d21f65f356f33fc80c5072eada87fb49437767ea2918b2c4b0", size = 423775, upload-time = "2025-07-03T16:57:35.932Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/b9/ab06c586aa5a5e7499017cee5ebab94ee260e75975c45395f32b8592abdd/anthropic-0.58.2.tar.gz", hash = "sha256:86396cc45530a83acea25ae6bca9f86656af81e3d598b4d22a1300e0e4cf8df8", size = 425125, upload-time = "2025-07-18T13:38:55.94Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/cf/ca0ba77805aec6171629a8b665c7dc224dab374539c3d27005b5d8c100a0/anthropic-0.57.1-py3-none-any.whl", hash = "sha256:33afc1f395af207d07ff1bffc0a3d1caac53c371793792569c5d2f09283ea306", size = 292779, upload-time = "2025-07-03T16:57:34.636Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f2/68d908ff308c9a65af5749ec31952e01d32f19ea073b0268affc616e6ebc/anthropic-0.58.2-py3-none-any.whl", hash = "sha256:3742181c634c725f337b71096839b6404145e33a8e190c75387c4028b825864d", size = 292896, upload-time = "2025-07-18T13:38:54.782Z" },
 ]
 
 [[package]]
@@ -285,8 +285,17 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "banks"
-version = "2.1.3"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
@@ -295,9 +304,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/5f/08a0c087581726044536e198c011742ccb9ced6061575f1ed00c034e6443/banks-2.1.3.tar.gz", hash = "sha256:c0dd2cb0c5487274a513a552827e6a8ddbd0ab1a1b967f177e71a6e4748a3ed2", size = 177311, upload-time = "2025-06-27T07:12:04.582Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/f8/25ef24814f77f3fd7f0fd3bd1ef3749e38a9dbd23502fbb53034de49900c/banks-2.2.0.tar.gz", hash = "sha256:d1446280ce6e00301e3e952dd754fd8cee23ff277d29ed160994a84d0d7ffe62", size = 179052, upload-time = "2025-07-18T16:28:26.892Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/27/a30c24a74cc4f3969f3e0d184da149fa6327620c7c72333ccc3a8e3e1095/banks-2.1.3-py3-none-any.whl", hash = "sha256:9e1217dc977e6dd1ce42c5ff48e9bcaf238d788c81b42deb6a555615ffcffbab", size = 28133, upload-time = "2025-06-27T07:12:05.986Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d6/f9168956276934162ec8d48232f9920f2985ee45aa7602e3c6b4bc203613/banks-2.2.0-py3-none-any.whl", hash = "sha256:963cd5c85a587b122abde4f4064078def35c50c688c1b9d36f43c92503854e7d", size = 29244, upload-time = "2025-07-18T16:28:27.835Z" },
 ]
 
 [[package]]
@@ -617,27 +626,27 @@ wheels = [
 
 [[package]]
 name = "debugpy"
-version = "1.8.14"
+version = "1.8.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bd/75/087fe07d40f490a78782ff3b0a30e3968936854105487decdb33446d4b0e/debugpy-1.8.14.tar.gz", hash = "sha256:7cd287184318416850aa8b60ac90105837bb1e59531898c07569d197d2ed5322", size = 1641444, upload-time = "2025-04-10T19:46:10.981Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/3a9a28ddb750a76eaec445c7f4d3147ea2c579a97dbd9e25d39001b92b21/debugpy-1.8.15.tar.gz", hash = "sha256:58d7a20b7773ab5ee6bdfb2e6cf622fdf1e40c9d5aef2857d85391526719ac00", size = 1643279, upload-time = "2025-07-15T16:43:29.135Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/df/156df75a41aaebd97cee9d3870fe68f8001b6c1c4ca023e221cfce69bece/debugpy-1.8.14-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:93fee753097e85623cab1c0e6a68c76308cd9f13ffdf44127e6fab4fbf024339", size = 2076510, upload-time = "2025-04-10T19:46:13.315Z" },
-    { url = "https://files.pythonhosted.org/packages/69/cd/4fc391607bca0996db5f3658762106e3d2427beaef9bfd363fd370a3c054/debugpy-1.8.14-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d937d93ae4fa51cdc94d3e865f535f185d5f9748efb41d0d49e33bf3365bd79", size = 3559614, upload-time = "2025-04-10T19:46:14.647Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/42/4e6d2b9d63e002db79edfd0cb5656f1c403958915e0e73ab3e9220012eec/debugpy-1.8.14-cp310-cp310-win32.whl", hash = "sha256:c442f20577b38cc7a9aafecffe1094f78f07fb8423c3dddb384e6b8f49fd2987", size = 5208588, upload-time = "2025-04-10T19:46:16.233Z" },
-    { url = "https://files.pythonhosted.org/packages/97/b1/cc9e4e5faadc9d00df1a64a3c2d5c5f4b9df28196c39ada06361c5141f89/debugpy-1.8.14-cp310-cp310-win_amd64.whl", hash = "sha256:f117dedda6d969c5c9483e23f573b38f4e39412845c7bc487b6f2648df30fe84", size = 5241043, upload-time = "2025-04-10T19:46:17.768Z" },
-    { url = "https://files.pythonhosted.org/packages/67/e8/57fe0c86915671fd6a3d2d8746e40485fd55e8d9e682388fbb3a3d42b86f/debugpy-1.8.14-cp311-cp311-macosx_14_0_universal2.whl", hash = "sha256:1b2ac8c13b2645e0b1eaf30e816404990fbdb168e193322be8f545e8c01644a9", size = 2175064, upload-time = "2025-04-10T19:46:19.486Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/97/2b2fd1b1c9569c6764ccdb650a6f752e4ac31be465049563c9eb127a8487/debugpy-1.8.14-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf431c343a99384ac7eab2f763980724834f933a271e90496944195318c619e2", size = 3132359, upload-time = "2025-04-10T19:46:21.192Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/ee/b825c87ed06256ee2a7ed8bab8fb3bb5851293bf9465409fdffc6261c426/debugpy-1.8.14-cp311-cp311-win32.whl", hash = "sha256:c99295c76161ad8d507b413cd33422d7c542889fbb73035889420ac1fad354f2", size = 5133269, upload-time = "2025-04-10T19:46:23.047Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/a6/6c70cd15afa43d37839d60f324213843174c1d1e6bb616bd89f7c1341bac/debugpy-1.8.14-cp311-cp311-win_amd64.whl", hash = "sha256:7816acea4a46d7e4e50ad8d09d963a680ecc814ae31cdef3622eb05ccacf7b01", size = 5158156, upload-time = "2025-04-10T19:46:24.521Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/2a/ac2df0eda4898f29c46eb6713a5148e6f8b2b389c8ec9e425a4a1d67bf07/debugpy-1.8.14-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:8899c17920d089cfa23e6005ad9f22582fd86f144b23acb9feeda59e84405b84", size = 2501268, upload-time = "2025-04-10T19:46:26.044Z" },
-    { url = "https://files.pythonhosted.org/packages/10/53/0a0cb5d79dd9f7039169f8bf94a144ad3efa52cc519940b3b7dde23bcb89/debugpy-1.8.14-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6bb5c0dcf80ad5dbc7b7d6eac484e2af34bdacdf81df09b6a3e62792b722826", size = 4221077, upload-time = "2025-04-10T19:46:27.464Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/d5/84e01821f362327bf4828728aa31e907a2eca7c78cd7c6ec062780d249f8/debugpy-1.8.14-cp312-cp312-win32.whl", hash = "sha256:281d44d248a0e1791ad0eafdbbd2912ff0de9eec48022a5bfbc332957487ed3f", size = 5255127, upload-time = "2025-04-10T19:46:29.467Z" },
-    { url = "https://files.pythonhosted.org/packages/33/16/1ed929d812c758295cac7f9cf3dab5c73439c83d9091f2d91871e648093e/debugpy-1.8.14-cp312-cp312-win_amd64.whl", hash = "sha256:5aa56ef8538893e4502a7d79047fe39b1dae08d9ae257074c6464a7b290b806f", size = 5297249, upload-time = "2025-04-10T19:46:31.538Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/e4/395c792b243f2367d84202dc33689aa3d910fb9826a7491ba20fc9e261f5/debugpy-1.8.14-cp313-cp313-macosx_14_0_universal2.whl", hash = "sha256:329a15d0660ee09fec6786acdb6e0443d595f64f5d096fc3e3ccf09a4259033f", size = 2485676, upload-time = "2025-04-10T19:46:32.96Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/f1/6f2ee3f991327ad9e4c2f8b82611a467052a0fb0e247390192580e89f7ff/debugpy-1.8.14-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f920c7f9af409d90f5fd26e313e119d908b0dd2952c2393cd3247a462331f15", size = 4217514, upload-time = "2025-04-10T19:46:34.336Z" },
-    { url = "https://files.pythonhosted.org/packages/79/28/b9d146f8f2dc535c236ee09ad3e5ac899adb39d7a19b49f03ac95d216beb/debugpy-1.8.14-cp313-cp313-win32.whl", hash = "sha256:3784ec6e8600c66cbdd4ca2726c72d8ca781e94bce2f396cc606d458146f8f4e", size = 5254756, upload-time = "2025-04-10T19:46:36.199Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/62/a7b4a57013eac4ccaef6977966e6bec5c63906dd25a86e35f155952e29a1/debugpy-1.8.14-cp313-cp313-win_amd64.whl", hash = "sha256:684eaf43c95a3ec39a96f1f5195a7ff3d4144e4a18d69bb66beeb1a6de605d6e", size = 5297119, upload-time = "2025-04-10T19:46:38.141Z" },
-    { url = "https://files.pythonhosted.org/packages/97/1a/481f33c37ee3ac8040d3d51fc4c4e4e7e61cb08b8bc8971d6032acc2279f/debugpy-1.8.14-py2.py3-none-any.whl", hash = "sha256:5cd9a579d553b6cb9759a7908a41988ee6280b961f24f63336835d9418216a20", size = 5256230, upload-time = "2025-04-10T19:46:54.077Z" },
+    { url = "https://files.pythonhosted.org/packages/69/51/0b4315169f0d945271db037ae6b98c0548a2d48cc036335cd1b2f5516c1b/debugpy-1.8.15-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:e9a8125c85172e3ec30985012e7a81ea5e70bbb836637f8a4104f454f9b06c97", size = 2084890, upload-time = "2025-07-15T16:43:31.239Z" },
+    { url = "https://files.pythonhosted.org/packages/36/cc/a5391dedb079280d7b72418022e00ba8227ae0b5bc8b2e3d1ecffc5d6b01/debugpy-1.8.15-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7fd0b6b5eccaa745c214fd240ea82f46049d99ef74b185a3517dad3ea1ec55d9", size = 3561470, upload-time = "2025-07-15T16:43:32.515Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/92/acf64b92010c66b33c077dee3862c733798a2c90e7d14b25c01d771e2a0d/debugpy-1.8.15-cp310-cp310-win32.whl", hash = "sha256:8181cce4d344010f6bfe94a531c351a46a96b0f7987750932b2908e7a1e14a55", size = 5229194, upload-time = "2025-07-15T16:43:33.997Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f5/c58c015c9ff78de35901bea3ab4dbf7946d7a4aa867ee73875df06ba6468/debugpy-1.8.15-cp310-cp310-win_amd64.whl", hash = "sha256:af2dcae4e4cd6e8b35f982ccab29fe65f7e8766e10720a717bc80c464584ee21", size = 5260900, upload-time = "2025-07-15T16:43:35.413Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b3/1c44a2ed311199ab11c2299c9474a6c7cd80d19278defd333aeb7c287995/debugpy-1.8.15-cp311-cp311-macosx_14_0_universal2.whl", hash = "sha256:babc4fb1962dd6a37e94d611280e3d0d11a1f5e6c72ac9b3d87a08212c4b6dd3", size = 2183442, upload-time = "2025-07-15T16:43:36.733Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/69/e2dcb721491e1c294d348681227c9b44fb95218f379aa88e12a19d85528d/debugpy-1.8.15-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f778e68f2986a58479d0ac4f643e0b8c82fdd97c2e200d4d61e7c2d13838eb53", size = 3134215, upload-time = "2025-07-15T16:43:38.116Z" },
+    { url = "https://files.pythonhosted.org/packages/17/76/4ce63b95d8294dcf2fd1820860b300a420d077df4e93afcaa25a984c2ca7/debugpy-1.8.15-cp311-cp311-win32.whl", hash = "sha256:f9d1b5abd75cd965e2deabb1a06b0e93a1546f31f9f621d2705e78104377c702", size = 5154037, upload-time = "2025-07-15T16:43:39.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a7/e5a7c784465eb9c976d84408873d597dc7ce74a0fc69ed009548a1a94813/debugpy-1.8.15-cp311-cp311-win_amd64.whl", hash = "sha256:62954fb904bec463e2b5a415777f6d1926c97febb08ef1694da0e5d1463c5c3b", size = 5178133, upload-time = "2025-07-15T16:43:40.969Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/4a/4508d256e52897f5cdfee6a6d7580974811e911c6d01321df3264508a5ac/debugpy-1.8.15-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:3dcc7225cb317469721ab5136cda9ff9c8b6e6fb43e87c9e15d5b108b99d01ba", size = 2511197, upload-time = "2025-07-15T16:43:42.343Z" },
+    { url = "https://files.pythonhosted.org/packages/99/8d/7f6ef1097e7fecf26b4ef72338d08e41644a41b7ee958a19f494ffcffc29/debugpy-1.8.15-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:047a493ca93c85ccede1dbbaf4e66816794bdc214213dde41a9a61e42d27f8fc", size = 4229517, upload-time = "2025-07-15T16:43:44.14Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e8/e8c6a9aa33a9c9c6dacbf31747384f6ed2adde4de2e9693c766bdf323aa3/debugpy-1.8.15-cp312-cp312-win32.whl", hash = "sha256:b08e9b0bc260cf324c890626961dad4ffd973f7568fbf57feb3c3a65ab6b6327", size = 5276132, upload-time = "2025-07-15T16:43:45.529Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/ad/231050c6177b3476b85fcea01e565dac83607b5233d003ff067e2ee44d8f/debugpy-1.8.15-cp312-cp312-win_amd64.whl", hash = "sha256:e2a4fe357c92334272eb2845fcfcdbec3ef9f22c16cf613c388ac0887aed15fa", size = 5317645, upload-time = "2025-07-15T16:43:46.968Z" },
+    { url = "https://files.pythonhosted.org/packages/28/70/2928aad2310726d5920b18ed9f54b9f06df5aa4c10cf9b45fa18ff0ab7e8/debugpy-1.8.15-cp313-cp313-macosx_14_0_universal2.whl", hash = "sha256:f5e01291ad7d6649aed5773256c5bba7a1a556196300232de1474c3c372592bf", size = 2495538, upload-time = "2025-07-15T16:43:48.927Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c6/9b8ffb4ca91fac8b2877eef63c9cc0e87dd2570b1120054c272815ec4cd0/debugpy-1.8.15-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94dc0f0d00e528d915e0ce1c78e771475b2335b376c49afcc7382ee0b146bab6", size = 4221874, upload-time = "2025-07-15T16:43:50.282Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8a/9b8d59674b4bf489318c7c46a1aab58e606e583651438084b7e029bf3c43/debugpy-1.8.15-cp313-cp313-win32.whl", hash = "sha256:fcf0748d4f6e25f89dc5e013d1129ca6f26ad4da405e0723a4f704583896a709", size = 5275949, upload-time = "2025-07-15T16:43:52.079Z" },
+    { url = "https://files.pythonhosted.org/packages/72/83/9e58e6fdfa8710a5e6ec06c2401241b9ad48b71c0a7eb99570a1f1edb1d3/debugpy-1.8.15-cp313-cp313-win_amd64.whl", hash = "sha256:73c943776cb83e36baf95e8f7f8da765896fd94b05991e7bc162456d25500683", size = 5317720, upload-time = "2025-07-15T16:43:53.703Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d5/98748d9860e767a1248b5e31ffa7ce8cb7006e97bf8abbf3d891d0a8ba4e/debugpy-1.8.15-py2.py3-none-any.whl", hash = "sha256:bce2e6c5ff4f2e00b98d45e7e01a49c7b489ff6df5f12d881c67d2f1ac635f3d", size = 5282697, upload-time = "2025-07-15T16:44:07.996Z" },
 ]
 
 [[package]]
@@ -690,11 +699,11 @@ wheels = [
 
 [[package]]
 name = "distlib"
-version = "0.3.9"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923, upload-time = "2024-10-09T18:35:47.551Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973, upload-time = "2024-10-09T18:35:44.272Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
 ]
 
 [[package]]
@@ -859,11 +868,11 @@ wheels = [
 
 [[package]]
 name = "fsspec"
-version = "2025.5.1"
+version = "2025.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/00/f7/27f15d41f0ed38e8fcc488584b57e902b331da7f7c6dcda53721b15838fc/fsspec-2025.5.1.tar.gz", hash = "sha256:2e55e47a540b91843b755e83ded97c6e897fa0942b11490113f09e9c443c2475", size = 303033, upload-time = "2025-05-24T12:03:23.792Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/02/0835e6ab9cfc03916fe3f78c0956cfcdb6ff2669ffa6651065d5ebf7fc98/fsspec-2025.7.0.tar.gz", hash = "sha256:786120687ffa54b8283d942929540d8bc5ccfa820deb555a2b5d0ed2b737bf58", size = 304432, upload-time = "2025-07-15T16:05:21.19Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/61/78c7b3851add1481b048b5fdc29067397a1784e2910592bc81bb3f608635/fsspec-2025.5.1-py3-none-any.whl", hash = "sha256:24d3a2e663d5fc735ab256263c4075f374a174c3410c0b25e5bd1970bceaa462", size = 199052, upload-time = "2025-05-24T12:03:21.66Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e0/014d5d9d7a4564cf1c40b5039bc882db69fd881111e03ab3657ac0b218e2/fsspec-2025.7.0-py3-none-any.whl", hash = "sha256:8b012e39f63c7d5f10474de957f3ab793b47b45ae7d39f2fb735f8bbe25c0e21", size = 199597, upload-time = "2025-07-15T16:05:19.529Z" },
 ]
 
 [[package]]
@@ -1227,7 +1236,7 @@ wheels = [
 
 [[package]]
 name = "jsonschema"
-version = "4.24.0"
+version = "4.25.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -1235,9 +1244,9 @@ dependencies = [
     { name = "referencing" },
     { name = "rpds-py" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/d3/1cf5326b923a53515d8f3a2cd442e6d7e94fcc444716e879ea70a0ce3177/jsonschema-4.24.0.tar.gz", hash = "sha256:0b4e8069eb12aedfa881333004bccaec24ecef5a8a6a4b6df142b2cc9599d196", size = 353480, upload-time = "2025-05-26T18:48:10.459Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/00/a297a868e9d0784450faa7365c2172a7d6110c763e30ba861867c32ae6a9/jsonschema-4.25.0.tar.gz", hash = "sha256:e63acf5c11762c0e6672ffb61482bdf57f0876684d8d249c0fe2d730d48bc55f", size = 356830, upload-time = "2025-07-18T15:39:45.11Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/3d/023389198f69c722d039351050738d6755376c8fd343e91dc493ea485905/jsonschema-4.24.0-py3-none-any.whl", hash = "sha256:a462455f19f5faf404a7902952b6f0e3ce868f3ee09a359b05eca6673bd8412d", size = 88709, upload-time = "2025-05-26T18:48:08.417Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/54/c86cd8e011fe98803d7e382fd67c0df5ceab8d2b7ad8c5a81524f791551c/jsonschema-4.25.0-py3-none-any.whl", hash = "sha256:24c2e8da302de79c8b9382fee3e76b355e44d2a4364bb207159ce10b517bd716", size = 89184, upload-time = "2025-07-18T15:39:42.956Z" },
 ]
 
 [package.optional-dependencies]
@@ -1248,6 +1257,7 @@ format-nongpl = [
     { name = "jsonpointer" },
     { name = "rfc3339-validator" },
     { name = "rfc3986-validator" },
+    { name = "rfc3987-syntax" },
     { name = "uri-template" },
     { name = "webcolors" },
 ]
@@ -1315,14 +1325,14 @@ wheels = [
 
 [[package]]
 name = "jupyter-lsp"
-version = "2.2.5"
+version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jupyter-server" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/b4/3200b0b09c12bc3b72d943d923323c398eff382d1dcc7c0dbc8b74630e40/jupyter-lsp-2.2.5.tar.gz", hash = "sha256:793147a05ad446f809fd53ef1cd19a9f5256fd0a2d6b7ce943a982cb4f545001", size = 48741, upload-time = "2024-04-09T17:59:44.918Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/3d/40bdb41b665d3302390ed1356cebd5917c10769d1f190ee4ca595900840e/jupyter_lsp-2.2.6.tar.gz", hash = "sha256:0566bd9bb04fd9e6774a937ed01522b555ba78be37bebef787c8ab22de4c0361", size = 48948, upload-time = "2025-07-18T21:35:19.885Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/e0/7bd7cff65594fd9936e2f9385701e44574fc7d721331ff676ce440b14100/jupyter_lsp-2.2.5-py3-none-any.whl", hash = "sha256:45fbddbd505f3fbfb0b6cb2f1bc5e15e83ab7c79cd6e89416b248cb3c00c11da", size = 69146, upload-time = "2024-04-09T17:59:43.388Z" },
+    { url = "https://files.pythonhosted.org/packages/47/7c/12f68daf85b469b4896d5e4a629baa33c806d61de75ac5b39d8ef27ec4a2/jupyter_lsp-2.2.6-py3-none-any.whl", hash = "sha256:283783752bf0b459ee7fa88effa72104d87dd343b82d5c06cf113ef755b15b6d", size = 69371, upload-time = "2025-07-18T21:35:16.585Z" },
 ]
 
 [[package]]
@@ -1418,6 +1428,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0a/c9/a883ce65eb27905ce77ace410d83587c82ea64dc85a48d1f7ed52bcfa68d/jupyterlab_server-2.27.3.tar.gz", hash = "sha256:eb36caca59e74471988f0ae25c77945610b887f777255aa21f8065def9e51ed4", size = 76173, upload-time = "2024-07-16T17:02:04.149Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/09/2032e7d15c544a0e3cd831c51d77a8ca57f7555b2e1b2922142eddb02a84/jupyterlab_server-2.27.3-py3-none-any.whl", hash = "sha256:e697488f66c3db49df675158a77b3b017520d772c6e1548c7d9bcc5df7944ee4", size = 59700, upload-time = "2024-07-16T17:02:01.115Z" },
+]
+
+[[package]]
+name = "lark"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/60/bc7622aefb2aee1c0b4ba23c1446d3e30225c8770b38d7aedbfb65ca9d5a/lark-1.2.2.tar.gz", hash = "sha256:ca807d0162cd16cef15a8feecb862d7319e7a09bdb13aef927968e45040fed80", size = 252132, upload-time = "2024-08-13T19:49:00.652Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/00/d90b10b962b4277f5e64a78b6609968859ff86889f5b898c1a778c06ec00/lark-1.2.2-py3-none-any.whl", hash = "sha256:c2276486b02f0f1b90be155f2c8ba4a8e194d42775786db622faccd652d8e80c", size = 111036, upload-time = "2024-08-13T19:48:58.603Z" },
 ]
 
 [[package]]
@@ -1570,15 +1589,15 @@ wheels = [
 
 [[package]]
 name = "llama-index-instrumentation"
-version = "0.2.0"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/03/6a34612ecc03ab05cd4818b989cbd7c6bf83e9ffa94c7275847a82ff4f9f/llama_index_instrumentation-0.2.0.tar.gz", hash = "sha256:ae8333522487e22a33732924a9a08dfb456f54993c5c97d8340db3c620b76f13", size = 44023, upload-time = "2025-06-20T15:50:05.191Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/57/76123657bf6f175382ceddee9af66507c37d603475cbf0968df8dfea9de2/llama_index_instrumentation-0.3.0.tar.gz", hash = "sha256:77741c1d9861ead080e6f98350625971488d1e046bede91cec9e0ce2f63ea34a", size = 42651, upload-time = "2025-07-17T17:41:20.468Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/b5/24ad1cf25b8c35b2075cfdd8c12d0f8390b7cfd54122ed704097bd755a2f/llama_index_instrumentation-0.2.0-py3-none-any.whl", hash = "sha256:1055ae7a3d19666671a8f1a62d08c90472552d9fcec7e84e6919b2acc92af605", size = 14966, upload-time = "2025-06-20T15:50:04.381Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d4/9377a53ea2f9bdd33f5ccff78ac863705657f422bb686cad4896b058ce46/llama_index_instrumentation-0.3.0-py3-none-any.whl", hash = "sha256:edfcd71aedc453dbdb4a7073a1e39ddef6ae2c13601a4cba6f2dfea38f48eeff", size = 15011, upload-time = "2025-07-17T17:41:19.723Z" },
 ]
 
 [[package]]
@@ -1842,6 +1861,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-dotenv" },
     { name = "python-dotenv" },
     { name = "selenium" },
 ]
@@ -1865,6 +1885,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
+    { name = "pytest-dotenv", marker = "extra == 'dev'" },
     { name = "python-dotenv", marker = "extra == 'dev'" },
     { name = "selenium", marker = "extra == 'dev'" },
 ]
@@ -2263,7 +2284,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.95.1"
+version = "1.97.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2275,9 +2296,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/a3/70cd57c7d71086c532ce90de5fdef4165dc6ae9dbf346da6737ff9ebafaa/openai-1.95.1.tar.gz", hash = "sha256:f089b605282e2a2b6776090b4b46563ac1da77f56402a222597d591e2dcc1086", size = 488271, upload-time = "2025-07-11T20:47:24.437Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/c6/b8d66e4f3b95493a8957065b24533333c927dc23817abe397f13fe589c6e/openai-1.97.0.tar.gz", hash = "sha256:0be349569ccaa4fb54f97bb808423fd29ccaeb1246ee1be762e0c81a47bae0aa", size = 493850, upload-time = "2025-07-16T16:37:35.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/1d/0432ea635097f4dbb34641a3650803d8a4aa29d06bafc66583bf1adcceb4/openai-1.95.1-py3-none-any.whl", hash = "sha256:8bbdfeceef231b1ddfabbc232b179d79f8b849aab5a7da131178f8d10e0f162f", size = 755613, upload-time = "2025-07-11T20:47:22.629Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/91/1f1cf577f745e956b276a8b1d3d76fa7a6ee0c2b05db3b001b900f2c71db/openai-1.97.0-py3-none-any.whl", hash = "sha256:a1c24d96f4609f3f7f51c9e1c2606d97cc6e334833438659cfd687e9c972c610", size = 764953, upload-time = "2025-07-16T16:37:33.135Z" },
 ]
 
 [[package]]
@@ -2857,14 +2878,15 @@ wheels = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/d4/14f53324cb1a6381bef29d698987625d80052bb33932d8e7cbf9b337b17c/pytest_asyncio-1.0.0.tar.gz", hash = "sha256:d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f", size = 46960, upload-time = "2025-05-26T04:54:40.484Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/05/ce271016e351fddc8399e546f6e23761967ee09c8c568bbfbecb0c150171/pytest_asyncio-1.0.0-py3-none-any.whl", hash = "sha256:4f024da9f1ef945e680dc68610b52550e36590a67fd31bb3b4943979a1f90ef3", size = 15976, upload-time = "2025-05-26T04:54:39.035Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
 ]
 
 [[package]]
@@ -2879,6 +2901,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/99/668cade231f434aaa59bbfbf49469068d2ddd945000621d3d165d2e7dd7b/pytest_cov-6.2.1.tar.gz", hash = "sha256:25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2", size = 69432, upload-time = "2025-06-12T10:47:47.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/16/4ea354101abb1287856baa4af2732be351c7bee728065aed451b678153fd/pytest_cov-6.2.1-py3-none-any.whl", hash = "sha256:f5bc4c23f42f1cdd23c70b1dab1bbaef4fc505ba950d53e0081d0730dd7e86d5", size = 24644, upload-time = "2025-06-12T10:47:45.932Z" },
+]
+
+[[package]]
+name = "pytest-dotenv"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/b0/cafee9c627c1bae228eb07c9977f679b3a7cb111b488307ab9594ba9e4da/pytest-dotenv-0.5.2.tar.gz", hash = "sha256:2dc6c3ac6d8764c71c6d2804e902d0ff810fa19692e95fe138aefc9b1aa73732", size = 3782, upload-time = "2020-06-16T12:38:03.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/da/9da67c67b3d0963160e3d2cbc7c38b6fae342670cc8e6d5936644b2cf944/pytest_dotenv-0.5.2-py3-none-any.whl", hash = "sha256:40a2cece120a213898afaa5407673f6bd924b1fa7eafce6bda0e8abffe2f710f", size = 3993, upload-time = "2020-06-16T12:38:01.139Z" },
 ]
 
 [[package]]
@@ -3176,6 +3211,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/da/88/f270de456dd7d11dcc808abfa291ecdd3f45ff44e3b549ffa01b126464d0/rfc3986_validator-0.1.1.tar.gz", hash = "sha256:3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055", size = 6760, upload-time = "2019-10-28T16:00:19.144Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/51/17023c0f8f1869d8806b979a2bffa3f861f26a3f1a66b094288323fba52f/rfc3986_validator-0.1.1-py2.py3-none-any.whl", hash = "sha256:2f235c432ef459970b4306369336b9d5dbdda31b510ca1e327636e01f528bfa9", size = 4242, upload-time = "2019-10-28T16:00:13.976Z" },
+]
+
+[[package]]
+name = "rfc3987-syntax"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lark" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd372515a97e32a83011f906ddded8d03e3c6aafbdedbb7/rfc3987_syntax-1.1.0-py3-none-any.whl", hash = "sha256:6c3d97604e4c5ce9f714898e05401a0445a641cfa276432b0a648c80856f6a3f", size = 8046, upload-time = "2025-07-18T01:05:03.843Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Make Python 3.10 instead of 3.9 the minimal required version.
- Extend `promising.Promise` from `asyncio.Future` to leverage the `.cancel()` "protocol".
- Implement rudimentary cancellation functionality (not fully functional yet).